### PR TITLE
Renaming ip release to remove.

### DIFF
--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -59,7 +59,7 @@ func BuildCommands(mainCommand commands.Command, mainConfig *config.Config) {
 	commands.BuildCommand(ip_address.ShowCommand(svc), ipAddressCommand, cfgFn())
 	commands.BuildCommand(ip_address.ModifyCommand(svc), ipAddressCommand, cfgFn())
 	commands.BuildCommand(ip_address.AssignCommand(svc, svc), ipAddressCommand, cfgFn())
-	commands.BuildCommand(ip_address.ReleaseCommand(svc), ipAddressCommand, cfgFn())
+	commands.BuildCommand(ip_address.RemoveCommand(svc), ipAddressCommand, cfgFn())
 
 	// Networks
 	networkCommand := commands.BuildCommand(network.NetworkCommand(), mainCommand, cfgFn())

--- a/internal/commands/ip_address/remove.go
+++ b/internal/commands/ip_address/remove.go
@@ -7,24 +7,24 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"
 )
 
-type releaseCommand struct {
+type removeCommand struct {
 	*commands.BaseCommand
 	service service.IpAddress
 }
 
-func ReleaseCommand(service service.IpAddress) commands.Command {
-	return &releaseCommand{
-		BaseCommand: commands.New("release", "Release an ip address"),
+func RemoveCommand(service service.IpAddress) commands.Command {
+	return &removeCommand{
+		BaseCommand: commands.New("remove", "Removes an ip address"),
 		service:     service,
 	}
 }
 
-func (s *releaseCommand) InitCommand() {
+func (s *removeCommand) InitCommand() {
 	s.SetPositionalArgHelp(positionalArgHelp)
 	s.ArgCompletion(GetArgCompFn(s.service))
 }
 
-func (s *releaseCommand) MakeExecuteCommand() func(args []string) (interface{}, error) {
+func (s *removeCommand) MakeExecuteCommand() func(args []string) (interface{}, error) {
 	return func(args []string) (interface{}, error) {
 		return Request{
 			BuildRequest: func(address string) interface{} {
@@ -35,7 +35,7 @@ func (s *releaseCommand) MakeExecuteCommand() func(args []string) (interface{}, 
 				RequestID:     func(in interface{}) string { return in.(*request.ReleaseIPAddressRequest).IPAddress },
 				MaxActions:    maxIpAddressActions,
 				InteractiveUI: s.Config().InteractiveUI(),
-				ActionMsg:     "Releasing IP Address",
+				ActionMsg:     "Removing IP Address",
 				Action: func(req interface{}) (interface{}, error) {
 					return nil, s.service.ReleaseIPAddress(req.(*request.ReleaseIPAddressRequest))
 				},

--- a/internal/commands/ip_address/remove_test.go
+++ b/internal/commands/ip_address/remove_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestReleaseCommand(t *testing.T) {
+func TestRemoveCommand(t *testing.T) {
 	methodName := "ReleaseIPAddress"
 
 	ip := upcloud.IPAddress{
@@ -45,7 +45,7 @@ func TestReleaseCommand(t *testing.T) {
 			mips.On(methodName, &test.expected).Return(nil)
 			mips.On("GetIPAddresses").Return(&upcloud.IPAddresses{IPAddresses: []upcloud.IPAddress{ip}}, nil)
 
-			c := commands.BuildCommand(ReleaseCommand(&mips), nil, config.New(viper.New()))
+			c := commands.BuildCommand(RemoveCommand(&mips), nil, config.New(viper.New()))
 
 			_, err := c.MakeExecuteCommand()(test.args)
 


### PR DESCRIPTION
underlying go api is still release. cli functions, info text and file names renamed from release to rename.