### PR TITLE
refactor: remove pagination support

### DIFF
--- a/internal/commands/ipaddress/list.go
+++ b/internal/commands/ipaddress/list.go
@@ -1,6 +1,7 @@
 package ipaddress
 
 import (
+	"fmt"
 	"github.com/UpCloudLtd/cli/internal/commands"
 	"github.com/UpCloudLtd/cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
@@ -68,5 +69,6 @@ func (s *listCommand) HandleOutput(writer io.Writer, out interface{}) error {
 			ip.Zone})
 	}
 
-	return t.Paginate(writer)
+	_, _ = fmt.Fprintln(writer, t.Render())
+	return nil
 }

--- a/internal/commands/network/list.go
+++ b/internal/commands/network/list.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"github.com/UpCloudLtd/cli/internal/commands"
 	"github.com/UpCloudLtd/cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
@@ -88,5 +89,6 @@ func (s *listCommand) HandleOutput(writer io.Writer, out interface{}) error {
 		})
 	}
 
-	return t.Paginate(writer)
+	_, _ = fmt.Fprintln(writer, t.Render())
+	return nil
 }

--- a/internal/commands/router/list.go
+++ b/internal/commands/router/list.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"github.com/UpCloudLtd/cli/internal/commands"
 	"github.com/UpCloudLtd/cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
@@ -63,5 +64,6 @@ func (s *listCommand) HandleOutput(writer io.Writer, out interface{}) error {
 		})
 	}
 
-	return t.Paginate(writer)
+	_, _ = fmt.Fprintln(writer, t.Render())
+	return nil
 }

--- a/internal/commands/server/list.go
+++ b/internal/commands/server/list.go
@@ -81,5 +81,6 @@ func (s *listCommand) HandleOutput(writer io.Writer, out interface{}) error {
 			server.License})
 	}
 
-	return t.Paginate(writer)
+	_, _ = fmt.Fprintln(writer, t.Render())
+	return nil
 }

--- a/internal/commands/server/plan_list.go
+++ b/internal/commands/server/plan_list.go
@@ -75,5 +75,6 @@ func (s *planListCommand) HandleOutput(writer io.Writer, out interface{}) error 
 		})
 	}
 
-	return t.Paginate(writer)
+	_, _ = fmt.Fprintln(writer, t.Render())
+	return nil
 }

--- a/internal/commands/storage/list.go
+++ b/internal/commands/storage/list.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"
 	"io"
 	"sort"
@@ -137,6 +138,6 @@ func (s *listCommand) HandleOutput(writer io.Writer, out interface{}) error {
 			storage.Created,
 			storage.Access})
 	}
-
-	return t.Paginate(writer)
+	_, _ = fmt.Fprintln(writer, t.Render())
+	return nil
 }


### PR DESCRIPTION
Remove `Paginate()` (and supporting methods) from DataTable and change `DataTable.Paginate(writer)` to `fmt.Fprintln(writer,DataTable.Render())` where it was used.

ref: https://app.asana.com/0/1199538382497508/1199943203283140