### PR TITLE
fix: don't try config load in init

### DIFF
--- a/cmd/upctl.go
+++ b/cmd/upctl.go
@@ -230,12 +230,6 @@ func (s *mainCommand) InitCommand() {
 		&defaultsCommand{commands.New("defaults", "Generate defaults")},
 		s, config.New(mainConfig.Viper()))
 
-	if loader := s.ConfigLoader(); loader != nil {
-		if err := loader(s.Config()); err != nil {
-			return
-		}
-	}
-
 	all.BuildCommands(s, s.Config())
 
 	s.Cobra().SetUsageTemplate(ui.CommandUsageTemplate())


### PR DESCRIPTION
Config load is already called when executing a cmd, don't duplicate the
call.
This also prevent service cmds from loading.

Signed-off-by: Amine Kherbouche <kaminek92@gmail.com>