### PR TITLE
fix(config/windows): use filepath instead of path to fix config loading on Windows

### DIFF
--- a/cmd/upctl/main.go
+++ b/cmd/upctl/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -202,8 +201,8 @@ func (s *mainCommand) initConfig() error {
 
 	if configFile := s.Config().GetString("config"); configFile != "" {
 		s.Config().Viper().SetConfigFile(configFile)
-		s.Config().Viper().SetConfigName(path.Base(configFile))
-		configDir := path.Dir(configFile)
+		s.Config().Viper().SetConfigName(filepath.Base(configFile))
+		configDir := filepath.Dir(configFile)
 		if configDir != "." && configDir != dir {
 			viper.AddConfigPath(configDir)
 		}


### PR DESCRIPTION
Previously, mainCommand.initConfig() used path.Base() to figure out the name of the config file. 

This does not work on Windows as `path` only supports forward-slash separators, for OS-agnostic paths we should use `filepath` instead. 