### PR TITLE
Fix module path to match repository name

### DIFF
--- a/cmd/upctl/main.go
+++ b/cmd/upctl/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/UpCloudLtd/cli/internal/commands/all"
-	"github.com/UpCloudLtd/cli/internal/config"
-	"github.com/UpCloudLtd/cli/internal/core"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/all"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/core"
 )
 
 // BootstrapCLI is the CLI entrypoint

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/UpCloudLtd/cli
+module github.com/UpCloudLtd/upcloud-cli
 
 go 1.13
 

--- a/internal/commands/account/account.go
+++ b/internal/commands/account/account.go
@@ -1,7 +1,7 @@
 package account
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 )
 
 // BaseAccountCommand creates the base 'account' command

--- a/internal/commands/account/show.go
+++ b/internal/commands/account/show.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 )
 
 // ShowCommand creates the 'account show' command

--- a/internal/commands/account/show_test.go
+++ b/internal/commands/account/show_test.go
@@ -2,12 +2,12 @@ package account
 
 import (
 	"bytes"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -1,18 +1,18 @@
 package all
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/commands/account"
-	"github.com/UpCloudLtd/cli/internal/commands/ipaddress"
-	"github.com/UpCloudLtd/cli/internal/commands/network"
-	"github.com/UpCloudLtd/cli/internal/commands/networkinterface"
-	"github.com/UpCloudLtd/cli/internal/commands/root"
-	"github.com/UpCloudLtd/cli/internal/commands/router"
-	"github.com/UpCloudLtd/cli/internal/commands/server"
-	"github.com/UpCloudLtd/cli/internal/commands/serverfirewall"
-	"github.com/UpCloudLtd/cli/internal/commands/serverstorage"
-	"github.com/UpCloudLtd/cli/internal/commands/storage"
-	"github.com/UpCloudLtd/cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/account"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/ipaddress"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/network"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/networkinterface"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/root"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/router"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/server"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/serverfirewall"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/serverstorage"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/storage"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/config"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/internal/commands/executor.go
+++ b/internal/commands/executor.go
@@ -2,10 +2,10 @@ package commands
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/config"
-	"github.com/UpCloudLtd/cli/internal/output"
-	internal "github.com/UpCloudLtd/cli/internal/service"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"
 	"os"
 	"time"

--- a/internal/commands/ipaddress/assign.go
+++ b/internal/commands/ipaddress/assign.go
@@ -2,9 +2,9 @@ package ipaddress
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/ipaddress/assign_test.go
+++ b/internal/commands/ipaddress/assign_test.go
@@ -3,9 +3,9 @@ package ipaddress
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/ipaddress/ip_address.go
+++ b/internal/commands/ipaddress/ip_address.go
@@ -2,7 +2,7 @@ package ipaddress
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"
 	"net"

--- a/internal/commands/ipaddress/ip_address_test.go
+++ b/internal/commands/ipaddress/ip_address_test.go
@@ -3,7 +3,7 @@ package ipaddress
 import (
 	"testing"
 
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"

--- a/internal/commands/ipaddress/list.go
+++ b/internal/commands/ipaddress/list.go
@@ -1,9 +1,9 @@
 package ipaddress
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 )
 
 // ListCommand creates the "ip-address list" command

--- a/internal/commands/ipaddress/modify.go
+++ b/internal/commands/ipaddress/modify.go
@@ -3,11 +3,11 @@ package ipaddress
 import (
 	"errors"
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"
 )

--- a/internal/commands/ipaddress/modify_test.go
+++ b/internal/commands/ipaddress/modify_test.go
@@ -3,9 +3,9 @@ package ipaddress
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/ipaddress/remove.go
+++ b/internal/commands/ipaddress/remove.go
@@ -2,11 +2,11 @@ package ipaddress
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 

--- a/internal/commands/ipaddress/remove_test.go
+++ b/internal/commands/ipaddress/remove_test.go
@@ -3,9 +3,9 @@ package ipaddress
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/ipaddress/show.go
+++ b/internal/commands/ipaddress/show.go
@@ -1,11 +1,11 @@
 package ipaddress
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 

--- a/internal/commands/ipaddress/show_test.go
+++ b/internal/commands/ipaddress/show_test.go
@@ -2,10 +2,10 @@ package ipaddress
 
 import (
 	"bytes"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 
 	"testing"

--- a/internal/commands/network/create.go
+++ b/internal/commands/network/create.go
@@ -2,10 +2,10 @@ package network
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/commands/ipaddress"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/ipaddress"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/network/create_test.go
+++ b/internal/commands/network/create_test.go
@@ -3,9 +3,9 @@ package network
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/network/delete.go
+++ b/internal/commands/network/delete.go
@@ -2,11 +2,11 @@ package network
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 

--- a/internal/commands/network/delete_test.go
+++ b/internal/commands/network/delete_test.go
@@ -3,9 +3,9 @@ package network
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/network/list.go
+++ b/internal/commands/network/list.go
@@ -1,9 +1,9 @@
 package network
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/network/list_test.go
+++ b/internal/commands/network/list_test.go
@@ -1,13 +1,13 @@
 package network
 
 import (
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/network/modify.go
+++ b/internal/commands/network/modify.go
@@ -2,11 +2,11 @@ package network
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/network/modify_test.go
+++ b/internal/commands/network/modify_test.go
@@ -3,9 +3,9 @@ package network
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/network/network.go
+++ b/internal/commands/network/network.go
@@ -2,8 +2,8 @@ package network
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"
 	"github.com/spf13/pflag"

--- a/internal/commands/network/network_test.go
+++ b/internal/commands/network/network_test.go
@@ -3,7 +3,7 @@ package network
 import (
 	"testing"
 
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"

--- a/internal/commands/network/show.go
+++ b/internal/commands/network/show.go
@@ -2,11 +2,11 @@ package network
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"strings"
 )

--- a/internal/commands/network/show_test.go
+++ b/internal/commands/network/show_test.go
@@ -2,13 +2,13 @@ package network
 
 import (
 	"bytes"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"

--- a/internal/commands/networkinterface/create.go
+++ b/internal/commands/networkinterface/create.go
@@ -2,11 +2,11 @@ package networkinterface
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/networkinterface/create_test.go
+++ b/internal/commands/networkinterface/create_test.go
@@ -3,9 +3,9 @@ package networkinterface
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/networkinterface/delete.go
+++ b/internal/commands/networkinterface/delete.go
@@ -3,11 +3,11 @@ package networkinterface
 import (
 	"errors"
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"
 )

--- a/internal/commands/networkinterface/delete_test.go
+++ b/internal/commands/networkinterface/delete_test.go
@@ -3,9 +3,9 @@ package networkinterface
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/networkinterface/modify.go
+++ b/internal/commands/networkinterface/modify.go
@@ -2,13 +2,13 @@ package networkinterface
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"
 )

--- a/internal/commands/networkinterface/modify_test.go
+++ b/internal/commands/networkinterface/modify_test.go
@@ -3,9 +3,9 @@ package networkinterface
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/networkinterface/network_interface.go
+++ b/internal/commands/networkinterface/network_interface.go
@@ -1,8 +1,8 @@
 package networkinterface
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/commands/ipaddress"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/ipaddress"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 

--- a/internal/commands/root/completion.go
+++ b/internal/commands/root/completion.go
@@ -3,9 +3,9 @@ package root
 import (
 	"bytes"
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 )
 
 // CompletionCommand creates shell completion scripts

--- a/internal/commands/root/version.go
+++ b/internal/commands/root/version.go
@@ -3,9 +3,9 @@ package root
 import (
 	"runtime"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 )
 
 // VersionCommand reports the current version of upctl

--- a/internal/commands/router/create.go
+++ b/internal/commands/router/create.go
@@ -2,9 +2,9 @@ package router
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"
 )

--- a/internal/commands/router/create_test.go
+++ b/internal/commands/router/create_test.go
@@ -3,9 +3,9 @@ package router
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/router/delete.go
+++ b/internal/commands/router/delete.go
@@ -2,11 +2,11 @@ package router
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 

--- a/internal/commands/router/delete_test.go
+++ b/internal/commands/router/delete_test.go
@@ -3,9 +3,9 @@ package router
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/router/list.go
+++ b/internal/commands/router/list.go
@@ -1,9 +1,9 @@
 package router
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/spf13/pflag"
 )

--- a/internal/commands/router/modify.go
+++ b/internal/commands/router/modify.go
@@ -2,11 +2,11 @@ package router
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"
 )

--- a/internal/commands/router/modify_test.go
+++ b/internal/commands/router/modify_test.go
@@ -3,9 +3,9 @@ package router
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/router/router.go
+++ b/internal/commands/router/router.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 )
 
 const maxRouterActions = 10

--- a/internal/commands/router/show.go
+++ b/internal/commands/router/show.go
@@ -1,11 +1,11 @@
 package router
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )

--- a/internal/commands/router/show_test.go
+++ b/internal/commands/router/show_test.go
@@ -2,11 +2,11 @@ package router
 
 import (
 	"bytes"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/commands/storage"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/storage"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/create_test.go
+++ b/internal/commands/server/create_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/commands/storage"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/storage"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/delete.go
+++ b/internal/commands/server/delete.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/server/delete_test.go
+++ b/internal/commands/server/delete_test.go
@@ -3,10 +3,10 @@ package server
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"

--- a/internal/commands/server/eject.go
+++ b/internal/commands/server/eject.go
@@ -3,11 +3,11 @@ package server
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )

--- a/internal/commands/server/eject_test.go
+++ b/internal/commands/server/eject_test.go
@@ -1,12 +1,12 @@
 package server
 
 import (
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/list.go
+++ b/internal/commands/server/list.go
@@ -3,8 +3,8 @@ package server
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 )
 
 // ListCommand creates the "server list" command

--- a/internal/commands/server/load.go
+++ b/internal/commands/server/load.go
@@ -3,12 +3,12 @@ package server
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/commands/storage"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/storage"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/server/load_test.go
+++ b/internal/commands/server/load_test.go
@@ -1,12 +1,12 @@
 package server
 
 import (
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/modify.go
+++ b/internal/commands/server/modify.go
@@ -3,11 +3,11 @@ package server
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/modify_test.go
+++ b/internal/commands/server/modify_test.go
@@ -1,12 +1,12 @@
 package server
 
 import (
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/plan_list.go
+++ b/internal/commands/server/plan_list.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 )
 
 // PlanListCommand creates the "server plans" command

--- a/internal/commands/server/restart.go
+++ b/internal/commands/server/restart.go
@@ -3,11 +3,11 @@ package server
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/server/restart_test.go
+++ b/internal/commands/server/restart_test.go
@@ -1,13 +1,13 @@
 package server
 
 import (
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"testing"
 	// "time"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -3,7 +3,7 @@ package server
 import (
 	"time"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )
 

--- a/internal/commands/server/show.go
+++ b/internal/commands/server/show.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/show_test.go
+++ b/internal/commands/server/show_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/start.go
+++ b/internal/commands/server/start.go
@@ -3,11 +3,11 @@ package server
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )

--- a/internal/commands/server/start_test.go
+++ b/internal/commands/server/start_test.go
@@ -1,12 +1,12 @@
 package server
 
 import (
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/server/stop.go
+++ b/internal/commands/server/stop.go
@@ -3,11 +3,11 @@ package server
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/server/stop_test.go
+++ b/internal/commands/server/stop_test.go
@@ -1,12 +1,12 @@
 package server
 
 import (
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/serverfirewall/create.go
+++ b/internal/commands/serverfirewall/create.go
@@ -2,11 +2,11 @@ package serverfirewall
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/m7shapan/cidr"

--- a/internal/commands/serverfirewall/create_test.go
+++ b/internal/commands/serverfirewall/create_test.go
@@ -3,9 +3,9 @@ package serverfirewall
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/serverfirewall/delete.go
+++ b/internal/commands/serverfirewall/delete.go
@@ -2,11 +2,11 @@ package serverfirewall
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"
 )

--- a/internal/commands/serverfirewall/delete_test.go
+++ b/internal/commands/serverfirewall/delete_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"

--- a/internal/commands/serverfirewall/server_firewall.go
+++ b/internal/commands/serverfirewall/server_firewall.go
@@ -1,7 +1,7 @@
 package serverfirewall
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 )
 
 // BaseServerFirewallCommand is the root command for all 'server firewall' commands

--- a/internal/commands/serverfirewall/show.go
+++ b/internal/commands/serverfirewall/show.go
@@ -2,10 +2,10 @@ package serverfirewall
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 )
 
 // ShowCommand is the 'server firewall show' command, displaying firewall details

--- a/internal/commands/serverfirewall/show_test.go
+++ b/internal/commands/serverfirewall/show_test.go
@@ -2,10 +2,10 @@ package serverfirewall
 
 import (
 	"bytes"
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"testing"
 

--- a/internal/commands/serverstorage/attach.go
+++ b/internal/commands/serverstorage/attach.go
@@ -3,12 +3,12 @@ package serverstorage
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/commands/storage"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/storage"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/serverstorage/attach_test.go
+++ b/internal/commands/serverstorage/attach_test.go
@@ -3,10 +3,10 @@ package serverstorage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/serverstorage/detach.go
+++ b/internal/commands/serverstorage/detach.go
@@ -3,11 +3,11 @@ package serverstorage
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/serverstorage/detach_test.go
+++ b/internal/commands/serverstorage/detach_test.go
@@ -3,10 +3,10 @@ package serverstorage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/serverstorage/server_storage.go
+++ b/internal/commands/serverstorage/server_storage.go
@@ -1,7 +1,7 @@
 package serverstorage
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 )
 
 const (

--- a/internal/commands/storage/backup.go
+++ b/internal/commands/storage/backup.go
@@ -1,6 +1,6 @@
 package storage
 
-import "github.com/UpCloudLtd/cli/internal/commands"
+import "github.com/UpCloudLtd/upcloud-cli/internal/commands"
 
 // BackupCommand creates the "storage backup" command
 func BackupCommand() commands.Command {

--- a/internal/commands/storage/backup_create.go
+++ b/internal/commands/storage/backup_create.go
@@ -3,11 +3,11 @@ package storage
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/storage/backup_create_test.go
+++ b/internal/commands/storage/backup_create_test.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/backup_restore.go
+++ b/internal/commands/storage/backup_restore.go
@@ -3,11 +3,11 @@ package storage
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )

--- a/internal/commands/storage/backup_restore_test.go
+++ b/internal/commands/storage/backup_restore_test.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/clone.go
+++ b/internal/commands/storage/clone.go
@@ -3,11 +3,11 @@ package storage
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/clone_test.go
+++ b/internal/commands/storage/clone_test.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/create.go
+++ b/internal/commands/storage/create.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/create_test.go
+++ b/internal/commands/storage/create_test.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/delete.go
+++ b/internal/commands/storage/delete.go
@@ -3,11 +3,11 @@ package storage
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 )

--- a/internal/commands/storage/delete_test.go
+++ b/internal/commands/storage/delete_test.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/import.go
+++ b/internal/commands/storage/import.go
@@ -3,8 +3,8 @@ package storage
 import (
 	"errors"
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"io"
 	"net/url"
@@ -13,8 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/spf13/pflag"

--- a/internal/commands/storage/import_test.go
+++ b/internal/commands/storage/import_test.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/list.go
+++ b/internal/commands/storage/list.go
@@ -1,9 +1,9 @@
 package storage
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/list_test.go
+++ b/internal/commands/storage/list_test.go
@@ -3,9 +3,9 @@ package storage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"

--- a/internal/commands/storage/modify.go
+++ b/internal/commands/storage/modify.go
@@ -2,12 +2,12 @@ package storage
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/modify_test.go
+++ b/internal/commands/storage/modify_test.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/show.go
+++ b/internal/commands/storage/show.go
@@ -1,11 +1,11 @@
 package storage
 
 import (
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"strings"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/show_test.go
+++ b/internal/commands/storage/show_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/storage/storage.go
+++ b/internal/commands/storage/storage.go
@@ -6,7 +6,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 )
 
 var (

--- a/internal/commands/storage/templatize.go
+++ b/internal/commands/storage/templatize.go
@@ -3,11 +3,11 @@ package storage
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/completion"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"

--- a/internal/commands/storage/templatize_test.go
+++ b/internal/commands/storage/templatize_test.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"testing"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"encoding/csv"
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/validation"
+	"github.com/UpCloudLtd/upcloud-cli/internal/validation"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"reflect"

--- a/internal/completion/completionprovider.go
+++ b/internal/completion/completionprovider.go
@@ -1,7 +1,7 @@
 package completion
 
 import (
-	"github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/completion/ipaddress.go
+++ b/internal/completion/ipaddress.go
@@ -1,7 +1,7 @@
 package completion
 
 import (
-	"github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/completion/network.go
+++ b/internal/completion/network.go
@@ -1,7 +1,7 @@
 package completion
 
 import (
-	"github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/completion/router.go
+++ b/internal/completion/router.go
@@ -1,7 +1,7 @@
 package completion
 
 import (
-	"github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/completion/server.go
+++ b/internal/completion/server.go
@@ -1,7 +1,7 @@
 package completion
 
 import (
-	"github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/completion/storage.go
+++ b/internal/completion/storage.go
@@ -1,7 +1,7 @@
 package completion
 
 import (
-	"github.com/UpCloudLtd/cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/cobra"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	internal "github.com/UpCloudLtd/cli/internal/service"
-	"github.com/UpCloudLtd/cli/internal/terminal"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-cli/internal/terminal"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"

--- a/internal/core/bootstrap.go
+++ b/internal/core/bootstrap.go
@@ -8,10 +8,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/UpCloudLtd/cli/internal/commands"
-	"github.com/UpCloudLtd/cli/internal/config"
-	"github.com/UpCloudLtd/cli/internal/terminal"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/terminal"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 )
 
 // BuildRootCmd builds the root command

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"gopkg.in/yaml.v2"
 )
 

--- a/internal/output/combined_test.go
+++ b/internal/output/combined_test.go
@@ -1,7 +1,7 @@
 package output_test
 
 import (
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/internal/output/details.go
+++ b/internal/output/details.go
@@ -3,7 +3,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"gopkg.in/yaml.v2"

--- a/internal/output/details_test.go
+++ b/internal/output/details_test.go
@@ -1,7 +1,7 @@
 package output_test
 
 import (
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -2,7 +2,7 @@ package output
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/jedib0t/go-pretty/v6/text"
 )

--- a/internal/output/marshaled_test.go
+++ b/internal/output/marshaled_test.go
@@ -1,7 +1,7 @@
 package output_test
 
 import (
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/UpCloudLtd/cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 )
 
 // Render renders commandOutput to writer using cfg to configure the output.

--- a/internal/output/render_test.go
+++ b/internal/output/render_test.go
@@ -3,8 +3,8 @@ package output_test
 import (
 	"bytes"
 	"errors"
-	"github.com/UpCloudLtd/cli/internal/config"
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -3,8 +3,8 @@ package output
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/ui"
-	"github.com/UpCloudLtd/cli/internal/validation"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-cli/internal/validation"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"gopkg.in/yaml.v2"

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -1,7 +1,7 @@
 package output_test
 
 import (
-	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/internal/resolver/completion.go
+++ b/internal/resolver/completion.go
@@ -1,7 +1,7 @@
 package resolver
 
 import (
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 )
 
 // CompletionResolver implements resolver for servers, caching the results

--- a/internal/resolver/ipaddress.go
+++ b/internal/resolver/ipaddress.go
@@ -1,7 +1,7 @@
 package resolver
 
 import (
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 )
 
 // CachingIPAddress implements resolver for ip addresses that resolve with ptr records, caching the results

--- a/internal/resolver/ipaddress_test.go
+++ b/internal/resolver/ipaddress_test.go
@@ -2,8 +2,8 @@ package resolver_test
 
 import (
 	"errors"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/internal/resolver/network.go
+++ b/internal/resolver/network.go
@@ -2,7 +2,7 @@ package resolver
 
 import (
 	"errors"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 )
 

--- a/internal/resolver/network_test.go
+++ b/internal/resolver/network_test.go
@@ -2,8 +2,8 @@ package resolver_test
 
 import (
 	"errors"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,6 +1,6 @@
 package resolver
 
-import "github.com/UpCloudLtd/cli/internal/service"
+import "github.com/UpCloudLtd/upcloud-cli/internal/service"
 
 // Resolver represents the most basic argument resolver, a function that accepts and argument and returns an uuid (or error)
 type Resolver func(arg string) (uuid string, err error)

--- a/internal/resolver/router.go
+++ b/internal/resolver/router.go
@@ -2,7 +2,7 @@ package resolver
 
 import (
 	"errors"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 )
 

--- a/internal/resolver/router_test.go
+++ b/internal/resolver/router_test.go
@@ -2,8 +2,8 @@ package resolver_test
 
 import (
 	"errors"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/internal/resolver/server.go
+++ b/internal/resolver/server.go
@@ -1,7 +1,7 @@
 package resolver
 
 import (
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 )
 
 // CachingServer implements resolver for servers, caching the results

--- a/internal/resolver/server_test.go
+++ b/internal/resolver/server_test.go
@@ -2,8 +2,8 @@ package resolver_test
 
 import (
 	"errors"
-	smock "github.com/UpCloudLtd/cli/internal/mock"
-	"github.com/UpCloudLtd/cli/internal/resolver"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/internal/resolver/storage.go
+++ b/internal/resolver/storage.go
@@ -2,7 +2,7 @@ package resolver
 
 import (
 	"errors"
-	internal "github.com/UpCloudLtd/cli/internal/service"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"

--- a/internal/ui/datatable.go
+++ b/internal/ui/datatable.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 
-	"github.com/UpCloudLtd/cli/internal/validation"
+	"github.com/UpCloudLtd/upcloud-cli/internal/validation"
 )
 
 func styleDataTable() table.Style {

--- a/internal/ui/log.go
+++ b/internal/ui/log.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jedib0t/go-pretty/v6/text"
 
-	"github.com/UpCloudLtd/cli/internal/terminal"
+	"github.com/UpCloudLtd/upcloud-cli/internal/terminal"
 )
 
 var (


### PR DESCRIPTION
Fixes:

```
go get: github.com/UpCloudLtd/upcloud-cli@v0.1.1: parsing go.mod:
	module declares its path as: github.com/UpCloudLtd/cli
	        but was required as: github.com/UpCloudLtd/upcloud-cli
```
