### PR TITLE
Refactor creation of command runE to unify execution of all types of commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       # - id: go-vet
       - id: go-lint
       - id: golangci-lint # implies go-vet, https://golangci-lint.run/usage/linters
-      - id: go-critic
+      # - id: go-critic # moved to be ran by golangci-lint, in order to configure
       - id: go-unit-tests
       - id: go-build
       - id: go-mod-tidy

--- a/internal/commands/runcommand.go
+++ b/internal/commands/runcommand.go
@@ -18,6 +18,7 @@ func commandRunE(command Command, config *config.Config) func(cmd *cobra.Command
 		return func(cmd *cobra.Command, args []string) error {
 			// need to pass in fake arguments here, to actually trigger execution
 			return execute(typedCommand, config, []string{""}, 1,
+				// FIXME: these bits panic go-critic unlambda check, figure out why and report upstream
 				func(exec Executor, fake string) (output.Output, error) {
 					return typedCommand.ExecuteWithoutArguments(exec)
 				})
@@ -28,6 +29,7 @@ func commandRunE(command Command, config *config.Config) func(cmd *cobra.Command
 			if len(args) != 1 || args[0] == "" {
 				return fmt.Errorf("exactly 1 argument is required")
 			}
+			// FIXME: these bits panic go-critic unlambda check, figure out why and report upstream
 			return execute(typedCommand, config, args, 1, func(exec Executor, arg string) (output.Output, error) {
 				return typedCommand.ExecuteSingleArgument(exec, arg)
 			})
@@ -38,6 +40,7 @@ func commandRunE(command Command, config *config.Config) func(cmd *cobra.Command
 			if len(args) < 1 {
 				return fmt.Errorf("at least one argument is required")
 			}
+			// FIXME: these bits panic go-critic unlambda check, figure out why and report upstream
 			return execute(typedCommand, config, args, typedCommand.MaximumExecutions(), func(exec Executor, arg string) (output.Output, error) {
 				return typedCommand.Execute(exec, arg)
 			})

--- a/internal/commands/runcommand.go
+++ b/internal/commands/runcommand.go
@@ -1,0 +1,153 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/UpCloudLtd/cli/internal/config"
+	"github.com/UpCloudLtd/cli/internal/output"
+	"github.com/UpCloudLtd/cli/internal/resolver"
+	internal "github.com/UpCloudLtd/cli/internal/service"
+	"github.com/spf13/cobra"
+	"os"
+	"time"
+)
+
+func commandRunE(command Command, config *config.Config) func(cmd *cobra.Command, args []string) error {
+
+	switch typedCommand := command.(type) {
+	case NoArgumentCommand:
+		return func(cmd *cobra.Command, args []string) error {
+			// need to pass in fake arguments here, to actually trigger execution
+			return execute(typedCommand, config, []string{""}, 1,
+				func(exec Executor, fake string) (output.Output, error) {
+					return typedCommand.ExecuteWithoutArguments(exec)
+				})
+		}
+	case SingleArgumentCommand:
+		return func(cmd *cobra.Command, args []string) error {
+			// make sure we have an argument
+			if len(args) != 1 || args[0] == "" {
+				return fmt.Errorf("exactly 1 argument is required")
+			}
+			return execute(typedCommand, config, args, 1, func(exec Executor, arg string) (output.Output, error) {
+				return typedCommand.ExecuteSingleArgument(exec, arg)
+			})
+		}
+	case MultipleArgumentCommand:
+		return func(cmd *cobra.Command, args []string) error {
+			// make sure we have arguments
+			if len(args) < 1 {
+				return fmt.Errorf("at least one argument is required")
+			}
+			return execute(typedCommand, config, args, typedCommand.MaximumExecutions(), func(exec Executor, arg string) (output.Output, error) {
+				return typedCommand.Execute(exec, arg)
+			})
+		}
+	default:
+		// no execution found on this command, eg. most likely an 'organizational' command
+		// so just show usage
+		return func(cmd *cobra.Command, args []string) error {
+			return cmd.Usage()
+		}
+	}
+
+}
+
+func render(config *config.Config, results []executeResult) error {
+	resultList := make([]output.Output, len(results))
+	for i := 0; i < len(results); i++ {
+		if results[i].Error != nil {
+			resultList[i] = output.Error{Value: results[i].Error}
+		} else {
+			resultList[i] = results[i].Result
+		}
+	}
+	return output.Render(os.Stdout, config, resultList...)
+}
+
+type resolvedArgument struct {
+	Resolved string
+	Error    error
+}
+
+func resolveArguments(nc Command, svc internal.AllServices, args []string) (out []resolvedArgument, err error) {
+	if resolve, ok := nc.(resolver.ResolutionProvider); ok {
+		argumentResolver, err := resolve.Get(svc)
+		if err != nil {
+			return nil, fmt.Errorf("cannot create resolver: %w", err)
+		}
+		for _, arg := range args {
+			resolved, err := argumentResolver(arg)
+			out = append(out, resolvedArgument{Resolved: resolved, Error: err})
+		}
+	} else {
+		for _, arg := range args {
+			out = append(out, resolvedArgument{Resolved: arg})
+		}
+	}
+	return
+}
+
+func execute(command Command, config *config.Config, args []string, parallelRuns int, executeCommand func(exec Executor, arg string) (output.Output, error)) error {
+	svc, err := config.CreateService()
+	if err != nil {
+		return fmt.Errorf("cannot create service: %w", err)
+	}
+	executor := NewExecutor(config, svc)
+	resolvedArgs, err := resolveArguments(command, svc, args)
+	if err != nil {
+		return fmt.Errorf("cannot create resolver: %w", err)
+	}
+
+	returnChan := make(chan executeResult)
+	workerCount := parallelRuns
+	workerQueue := make(chan int, workerCount)
+
+	// push initial workers into the worker queue
+	for n := 0; n < workerCount; n++ {
+		workerQueue <- n
+	}
+
+	// make a copy of the original args to pass into the workers
+	argQueue := resolvedArgs
+
+	results := make([]executeResult, 0, len(args))
+	renderTicker := time.NewTicker(100 * time.Millisecond)
+
+	for {
+		select {
+		case workerID := <-workerQueue:
+			// got an idle worker
+			if len(argQueue) == 0 {
+				// we are out of arguments to process, just let the worker exit
+				break
+			}
+			arg := argQueue[0]
+			argQueue = argQueue[1:]
+			// trigger execution in a goroutine
+			go func(index int, argument resolvedArgument) {
+				defer func() {
+					// return worker to queue when exiting
+					workerQueue <- workerID
+				}()
+				if argument.Error != nil {
+					// argument wasn't parsed correctly, pass the error on
+					returnChan <- executeResult{Job: index, Error: fmt.Errorf("cannot resolve argument: %w", argument.Error)}
+				} else {
+					// otherwise, execute and return results
+					res, err := executeCommand(executor, argument.Resolved)
+					returnChan <- executeResult{Job: index, Result: res, Error: err}
+				}
+			}(workerID, arg)
+		case res := <-returnChan:
+			// got a result from a worker
+			results = append(results, res)
+			if len(results) >= len(args) {
+				// we're done, update ui for the last time and render the results
+				executor.Update()
+				return render(config, results)
+			}
+		case <-renderTicker.C:
+			executor.Update()
+		}
+	}
+}

--- a/internal/commands/runcommand.go
+++ b/internal/commands/runcommand.go
@@ -2,13 +2,14 @@ package commands
 
 import (
 	"fmt"
-	"github.com/UpCloudLtd/cli/internal/config"
-	"github.com/UpCloudLtd/cli/internal/output"
-	"github.com/UpCloudLtd/cli/internal/resolver"
-	internal "github.com/UpCloudLtd/cli/internal/service"
-	"github.com/spf13/cobra"
 	"os"
 	"time"
+
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
+	"github.com/spf13/cobra"
 )
 
 func commandRunE(command Command, config *config.Config) func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -313,21 +313,8 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 		logline.SetDetails(err.Error(), "error: ")
 		return nil, err
 	}
-	// TODO: reimplmement
-	/*	if exec.Config().GlobalFlags.Wait {
 
-		logline.SetMessage(fmt.Sprintf("%s: waiting to start", msg))
-		if err := exec.WaitFor(
-			serverStateWaiter(res.UUID, upcloud.ServerStateStarted, msg, serverSvc, logline),
-			s.Config().ClientTimeout(),
-		); err != nil {
-			return nil, err
-		}
-	} else {*/
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
-	//}
-
-	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
 	return output.Marshaled{Value: res}, nil

--- a/internal/commands/server/restart.go
+++ b/internal/commands/server/restart.go
@@ -66,31 +66,8 @@ func (s *restartCommand) Execute(exec commands.Executor, uuid string) (output.Ou
 		logline.SetDetails(err.Error(), "error: ")
 		return nil, err
 	}
-	// TODO: reimplmement
-	/*	if s.Config().GlobalFlags.Wait {
-		// TODO: this seems to not work as expected as the backend will report
-		// started->maintenance->started->maintenance..
-		logline.SetMessage(fmt.Sprintf("%s: waiting to restart", msg))
-		if err := exec.WaitFor(
-			serverStateWaiter(uuid, upcloud.ServerStateMaintenance, msg, svc, logline),
-			s.Config().ClientTimeout(),
-		); err != nil {
-			return nil, err
-		}
 
-		logline.SetMessage(fmt.Sprintf("%s: waiting to start", msg))
-		if err := exec.WaitFor(
-			serverStateWaiter(uuid, upcloud.ServerStateStarted, msg, svc, logline),
-			s.Config().ClientTimeout(),
-		); err != nil {
-			return nil, err
-		}
-
-		logline.SetMessage(fmt.Sprintf("%s: server restarted", msg))
-	} else {*/
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
-	//}
-
 	logline.MarkDone()
 
 	return output.Marshaled{Value: res}, nil

--- a/internal/commands/server/start.go
+++ b/internal/commands/server/start.go
@@ -46,18 +46,8 @@ func (s *startCommand) Execute(exec commands.Executor, uuid string) (output.Outp
 		logline.SetDetails(err.Error(), "error: ")
 		return nil, err
 	}
-	// TODO: reimplmement
-	/*	if s.Config().GlobalFlags.Wait {
-		logline.SetMessage(fmt.Sprintf("%s: waiting to start", msg))
-		if err := exec.WaitFor(serverStateWaiter(uuid, upcloud.ServerStateStarted, msg, svc, logline), s.Config().ClientTimeout()); err != nil {
-			return nil, err
-		}
 
-		logline.SetMessage(fmt.Sprintf("%s: server started", msg))
-	} else {*/
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
-	//}
-
 	logline.MarkDone()
 
 	return output.Marshaled{Value: res}, nil

--- a/internal/commands/server/stop.go
+++ b/internal/commands/server/stop.go
@@ -54,18 +54,7 @@ func (s *stopCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 		return nil, err
 	}
 
-	// TODO: reimplmement
-	/*if s.Config().GlobalFlags.Wait {
-		logline.SetMessage(fmt.Sprintf("%s: waiting to stop", msg))
-		if err := exec.WaitFor(serverStateWaiter(uuid, upcloud.ServerStateStopped, msg, svc, logline), s.Config().ClientTimeout()); err != nil {
-			return nil, err
-		}
-
-		logline.SetMessage(fmt.Sprintf("%s: server stoped", msg))
-	} else {*/
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
-	//}
-
 	logline.MarkDone()
 
 	return output.Marshaled{Value: res}, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,7 +52,6 @@ type GlobalFlags struct {
 	OutputFormat  string        `valid:"in(human|json|yaml)"`
 	Colors        bool          `valid:"-"`
 	ClientTimeout time.Duration `valid:"-"`
-	Wait          bool          `valid:"-"`
 }
 
 // Config holds the configuration for running upctl

--- a/internal/core/bootstrap.go
+++ b/internal/core/bootstrap.go
@@ -64,10 +64,6 @@ func BuildRootCmd(_ []string, conf *config.Config) cobra.Command {
 		time.Duration(60*time.Second),
 		"CLI timeout when using interactive mode on some commands",
 	)
-	flags.BoolVarP(
-		&conf.GlobalFlags.Wait, "wait", "w", false,
-		"Wait for the command to be completed",
-	)
 
 	// XXX: Apply viper value to the help as default
 	// Add flags


### PR DESCRIPTION
The previous refactoring related to argument handling introduced a regression; other execution modes except the multiple/parallel mode would not create any output. 

This MR refactors how the RunE method is generated for the different types of argument handling commands. Plenty of bits were DRYed up and the separate bits have been split apart to logical pieces.