### PR TITLE
Add a way to return extra information in humanized output

### DIFF
--- a/internal/commands/ipaddress/assign.go
+++ b/internal/commands/ipaddress/assign.go
@@ -85,5 +85,5 @@ func (s *assignCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	}
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/ipaddress/modify.go
+++ b/internal/commands/ipaddress/modify.go
@@ -62,5 +62,5 @@ func (s *modifyCommand) Execute(exec commands.Executor, arg string) (output.Outp
 	}
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/network/create.go
+++ b/internal/commands/network/create.go
@@ -118,5 +118,5 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	}
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/network/modify.go
+++ b/internal/commands/network/modify.go
@@ -81,5 +81,5 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 	}
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/networkinterface/create.go
+++ b/internal/commands/networkinterface/create.go
@@ -111,5 +111,5 @@ func (s *createCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/networkinterface/modify.go
+++ b/internal/commands/networkinterface/modify.go
@@ -93,5 +93,5 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/router/create.go
+++ b/internal/commands/router/create.go
@@ -53,5 +53,5 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/router/modify.go
+++ b/internal/commands/router/modify.go
@@ -50,5 +50,5 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bufio"
 	"fmt"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"os"
 	"strings"
 
@@ -317,5 +318,19 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
 	logline.MarkDone()
 
-	return output.OnlyMarshaled{Value: res}, nil
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "UUID", Value: res.UUID, Color: ui.DefaultUUUIDColours},
+		{Title: "IP Addresses", Value: res.IPAddresses, Format: formatIPAddresses},
+	}}, nil
+}
+
+func formatIPAddresses(val interface{}) (text.Colors, string, error) {
+	if ipAddresses, ok := val.(upcloud.IPAddressSlice); ok {
+		strs := make([]string, len(ipAddresses))
+		for i, ipa := range ipAddresses {
+			strs[i] = ipa.Address
+		}
+		return nil, strings.Join(strs, ",\n"), nil
+	}
+	return nil, fmt.Sprint(val), nil
 }

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -317,5 +317,5 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/server/eject.go
+++ b/internal/commands/server/eject.go
@@ -55,5 +55,5 @@ func (s *ejectCommand) Execute(exec commands.Executor, uuid string) (output.Outp
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/server/load.go
+++ b/internal/commands/server/load.go
@@ -79,5 +79,5 @@ func (s *loadCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/server/modify.go
+++ b/internal/commands/server/modify.go
@@ -106,5 +106,5 @@ func (s *modifyCommand) Execute(exec commands.Executor, uuid string) (output.Out
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/server/restart.go
+++ b/internal/commands/server/restart.go
@@ -70,5 +70,5 @@ func (s *restartCommand) Execute(exec commands.Executor, uuid string) (output.Ou
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/server/start.go
+++ b/internal/commands/server/start.go
@@ -50,5 +50,5 @@ func (s *startCommand) Execute(exec commands.Executor, uuid string) (output.Outp
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/server/stop.go
+++ b/internal/commands/server/stop.go
@@ -57,5 +57,5 @@ func (s *stopCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/serverfirewall/create.go
+++ b/internal/commands/serverfirewall/create.go
@@ -156,6 +156,6 @@ func (s *createCommand) Execute(exec commands.Executor, arg string) (output.Outp
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 
 }

--- a/internal/commands/serverstorage/attach.go
+++ b/internal/commands/serverstorage/attach.go
@@ -96,5 +96,5 @@ func (s *attachCommand) ExecuteSingleArgument(exec commands.Executor, uuid strin
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/serverstorage/detach.go
+++ b/internal/commands/serverstorage/detach.go
@@ -76,5 +76,5 @@ func (s *detachCommand) ExecuteSingleArgument(exec commands.Executor, uuid strin
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/storage/backup_create.go
+++ b/internal/commands/storage/backup_create.go
@@ -69,5 +69,5 @@ func (s *createBackupCommand) Execute(exec commands.Executor, uuid string) (outp
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/storage/clone.go
+++ b/internal/commands/storage/clone.go
@@ -76,5 +76,5 @@ func (s *cloneCommand) Execute(exec commands.Executor, uuid string) (output.Outp
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/storage/create.go
+++ b/internal/commands/storage/create.go
@@ -107,5 +107,5 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/storage/import.go
+++ b/internal/commands/storage/import.go
@@ -260,7 +260,7 @@ func (s *importCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 					case details.State == upcloud.StorageImportStateCompleted:
 						logline.SetMessage(fmt.Sprintf("%s: done", msg))
 						logline.MarkDone()
-						return output.Marshaled{Value: createdStorageImport}, nil
+						return output.OnlyMarshaled{Value: createdStorageImport}, nil
 					}
 					if read := details.ReadBytes; read > 0 {
 						if details.ClientContentLength > 0 {

--- a/internal/commands/storage/modify.go
+++ b/internal/commands/storage/modify.go
@@ -149,5 +149,5 @@ func (s *modifyCommand) Execute(exec commands.Executor, uuid string) (output.Out
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/storage/templatize.go
+++ b/internal/commands/storage/templatize.go
@@ -72,5 +72,5 @@ func (s *templatizeCommand) Execute(exec commands.Executor, uuid string) (output
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
 
-	return output.Marshaled{Value: res}, nil
+	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/output/marshaled.go
+++ b/internal/output/marshaled.go
@@ -7,14 +7,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// Marshaled implements output.Command for a return value that is only displayed as raw marshaled in JSON and YAML
+// OnlyMarshaled implements output.Command for a return value that is only displayed as raw marshaled in JSON and YAML
 // eg. most 'state change' commands
-type Marshaled struct {
+type OnlyMarshaled struct {
 	Value interface{}
 }
 
 // MarshalJSON implements json.Marshaler and output.Output
-func (d Marshaled) MarshalJSON() ([]byte, error) {
+func (d OnlyMarshaled) MarshalJSON() ([]byte, error) {
 	if errValue, ok := d.Value.(error); ok {
 		return json.MarshalIndent(map[string]interface{}{
 			"error": errValue.Error(),
@@ -25,7 +25,7 @@ func (d Marshaled) MarshalJSON() ([]byte, error) {
 
 // MarshalYAML implements output.Output, it marshals the value and returns the YAML as []byte
 // nb. does *not* implement yaml.Marshaler
-func (d Marshaled) MarshalYAML() ([]byte, error) {
+func (d OnlyMarshaled) MarshalYAML() ([]byte, error) {
 	if errValue, ok := d.Value.(error); ok {
 		return yaml.Marshal(map[string]interface{}{
 			"error": errValue.Error(),
@@ -35,9 +35,9 @@ func (d Marshaled) MarshalYAML() ([]byte, error) {
 }
 
 // MarshalHuman implements output.Output
-// For Marshaled outputs, we dont return anything in humanized output as it's assumed the log output is what the user
+// For OnlyMarshaled outputs, we dont return anything in humanized output as it's assumed the log output is what the user
 // wants and it is down to the command itself to provide that.
-func (d Marshaled) MarshalHuman() ([]byte, error) {
+func (d OnlyMarshaled) MarshalHuman() ([]byte, error) {
 	if errValue, ok := d.Value.(error); ok {
 		return []byte(fmt.Sprintf("ERROR: %v", errValue)), nil
 	}
@@ -45,6 +45,6 @@ func (d Marshaled) MarshalHuman() ([]byte, error) {
 }
 
 // MarshalRawMap implements output.Output
-func (d Marshaled) MarshalRawMap() (map[string]interface{}, error) {
+func (d OnlyMarshaled) MarshalRawMap() (map[string]interface{}, error) {
 	return nil, errors.New("marshaled should not be used as part of multiple output, raw output is undefined")
 }

--- a/internal/output/marshaled_test.go
+++ b/internal/output/marshaled_test.go
@@ -43,7 +43,7 @@ var marshaledTests = []struct {
 func TestMarshaled(t *testing.T) {
 	for _, test := range marshaledTests {
 		t.Run(test.name, func(t *testing.T) {
-			input := output.Marshaled{Value: test.marshalValue}
+			input := output.OnlyMarshaled{Value: test.marshalValue}
 			if test.expectedErrorMessage == "" {
 				bytes, err := input.MarshalHuman()
 				assert.NoError(t, err)

--- a/internal/output/marshaledwithhumandetails.go
+++ b/internal/output/marshaledwithhumandetails.go
@@ -1,0 +1,48 @@
+package output
+
+import (
+	"encoding/json"
+	"errors"
+	"gopkg.in/yaml.v2"
+)
+
+// MarshaledWithHumanDetails implements output.Command for a return value that is only displayed as raw marshaled in JSON and YAML
+// eg. most 'state change' commands
+type MarshaledWithHumanDetails struct {
+	Value   interface{}
+	Details []DetailRow
+}
+
+// MarshalJSON implements json.Marshaler and output.Output
+func (d MarshaledWithHumanDetails) MarshalJSON() ([]byte, error) {
+	if errValue, ok := d.Value.(error); ok {
+		return json.MarshalIndent(map[string]interface{}{
+			"error": errValue.Error(),
+		}, "", "  ")
+	}
+	return json.MarshalIndent(d.Value, "", "  ")
+}
+
+// MarshalYAML implements output.Output, it marshals the value and returns the YAML as []byte
+// nb. does *not* implement yaml.Marshaler
+func (d MarshaledWithHumanDetails) MarshalYAML() ([]byte, error) {
+	if errValue, ok := d.Value.(error); ok {
+		return yaml.Marshal(map[string]interface{}{
+			"error": errValue.Error(),
+		})
+	}
+	return yaml.Marshal(d.Value)
+}
+
+// MarshalHuman implements output.Output
+// For MarshaledWithHumanDetails outputs, we return *only* the details part in humanized output
+func (d MarshaledWithHumanDetails) MarshalHuman() ([]byte, error) {
+	return Details{Sections: []DetailSection{
+		{Rows: d.Details},
+	}}.MarshalHuman()
+}
+
+// MarshalRawMap implements output.Output
+func (d MarshaledWithHumanDetails) MarshalRawMap() (map[string]interface{}, error) {
+	return nil, errors.New("marshaled should not be used as part of multiple output, raw output is undefined")
+}

--- a/internal/output/render_test.go
+++ b/internal/output/render_test.go
@@ -41,7 +41,7 @@ func TestRender(t *testing.T) {
 		},
 		{
 			name:                "marshaled",
-			output:              output.Marshaled{Value: "hello"},
+			output:              output.OnlyMarshaled{Value: "hello"},
 			expectedHumanResult: "\n", // marshaled should not output in human mode
 			expectedJSONResult: `"hello"
 `,


### PR DESCRIPTION
- Rename output.Marshaled to output.MarshaledOnly to make it clear(er?) that it only outputs in marshaled outputs (even better names welcome)
- add output.MarshaledWithHumanDetails that allows us one section of details (as in output.Details) to be outputed after execution in human output mode