### PR TITLE
Refactor runcommand, again

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,8 @@
+linters-settings:
+  gocritic:
+    disabled-checks:
+      # TODO: re-enable after figuring out why runcommand fails on go-critic..
+      - unlambda
+linters:
+  enable:
+    - gocritic

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -91,7 +91,13 @@ func BuildCommand(child Command, parent *cobra.Command, config *config.Config) C
 	}
 
 	// Set run
-	child.Cobra().RunE = commandRunE(child, config)
+	child.Cobra().RunE = func(cmd *cobra.Command, args []string) error {
+		service, err := config.CreateService()
+		if err != nil {
+			return fmt.Errorf("cannot create service: %w", err)
+		}
+		return commandRunE(child, service, config, args)
+	}
 
 	return child
 }


### PR DESCRIPTION
This PR refactors runcommand to accept service from outside, in order to facilitate testing the runcommand logic. Previously, service was created within execute() which made it impossible to pass in mock service. 

Also makes the runcommand a bit more straightforward with less return func()s and adds the forgotten golangci config that disables just the unlambda test (which still panics with this code). 