### PR TITLE
Add v0.6.0 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2021-04-16
+### Changed
+- Use goreleaser for releasing packages
+- Move creation of service outside runcommand to facilitate testing
+
+### Fixes
+- fix(pre-commit): add missing golangci config file
+- fix(root): use default cobra behavious when called
+
 ## [0.5.0] - 2021-04-14
 Initial public beta release :tada:
 
@@ -33,7 +42,8 @@ Initial public beta release :tada:
 ### Added
 - Current feature set added! First internal release
 
-[Unreleased]: https://github.com/UpCloudLtd/upcloud-cli/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/UpCloudLtd/upcloud-cli/compare/v0.6.0...HEAD
 [0.1.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v0.1.0
 [0.1.1]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v0.1.1
 [0.5.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v0.5.0
+[0.5.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v0.6.0


### PR DESCRIPTION
This adds v0.6.0 to CHANGELOG.md and fixes "Unreleased" to point to unreleased changes again.