### PR TITLE
Refactor runcommand some more

### DIFF
--- a/internal/commands/executor_test.go
+++ b/internal/commands/executor_test.go
@@ -1,0 +1,52 @@
+package commands_test
+
+import (
+	"fmt"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestExecutor_WaitFor(t *testing.T) {
+	mService := &smock.Service{}
+	cfg := config.New()
+	exec := commands.NewExecutor(cfg, mService)
+	finished := false
+	// normal operation
+	go func() {
+		err := exec.WaitFor(func() error {
+			time.Sleep(50 * time.Millisecond)
+			finished = true
+			return nil
+		}, time.Minute)
+		assert.NoError(t, err)
+	}()
+	assert.Eventually(t, func() bool {
+		return finished
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestExecutor_WaitForTimeout(t *testing.T) {
+	mService := &smock.Service{}
+	cfg := config.New()
+	exec := commands.NewExecutor(cfg, mService)
+	err := exec.WaitFor(func() error {
+		time.Sleep(50 * time.Minute)
+		return nil
+	}, 100*time.Millisecond)
+	assert.EqualError(t, err, "timed out")
+}
+
+func TestExecutor_WaitForError(t *testing.T) {
+	mService := &smock.Service{}
+	cfg := config.New()
+	exec := commands.NewExecutor(cfg, mService)
+	err := exec.WaitFor(func() error {
+		time.Sleep(10 * time.Millisecond)
+		return fmt.Errorf("mockmock")
+	}, 100*time.Millisecond)
+	assert.EqualError(t, err, "mockmock")
+}

--- a/internal/commands/runcommand.go
+++ b/internal/commands/runcommand.go
@@ -15,29 +15,35 @@ func commandRunE(command Command, service internal.AllServices, config *config.C
 	switch typedCommand := command.(type) {
 	case NoArgumentCommand:
 		// need to pass in fake arguments here, to actually trigger execution
-		return execute(typedCommand, service, config, []string{""}, 1,
-			// FIXME: these bits panic go-critic unlambda check, figure out why and report upstream
+		results, err := execute(typedCommand, service, config, []string{""}, 1,
+			// FIXME: this bit panics go-critic unlambda check, figure out why and report upstream
 			func(exec Executor, fake string) (output.Output, error) {
 				return typedCommand.ExecuteWithoutArguments(exec)
 			})
+		if err != nil {
+			return err
+		}
+		return render(config, results)
 	case SingleArgumentCommand:
 		// make sure we have an argument
 		if len(args) != 1 || args[0] == "" {
 			return fmt.Errorf("exactly 1 argument is required")
 		}
-		// FIXME: these bits panic go-critic unlambda check, figure out why and report upstream
-		return execute(typedCommand, service, config, args, 1, func(exec Executor, arg string) (output.Output, error) {
-			return typedCommand.ExecuteSingleArgument(exec, arg)
-		})
+		results, err := execute(typedCommand, service, config, args, 1, typedCommand.ExecuteSingleArgument)
+		if err != nil {
+			return err
+		}
+		return render(config, results)
 	case MultipleArgumentCommand:
 		// make sure we have arguments
 		if len(args) < 1 {
 			return fmt.Errorf("at least one argument is required")
 		}
-		// FIXME: these bits panic go-critic unlambda check, figure out why and report upstream
-		return execute(typedCommand, service, config, args, typedCommand.MaximumExecutions(), func(exec Executor, arg string) (output.Output, error) {
-			return typedCommand.Execute(exec, arg)
-		})
+		results, err := execute(typedCommand, service, config, args, typedCommand.MaximumExecutions(), typedCommand.Execute)
+		if err != nil {
+			return err
+		}
+		return render(config, results)
 	default:
 		// no execution found on this command, eg. most likely an 'organizational' command
 		// so just show usage
@@ -80,11 +86,11 @@ func resolveArguments(nc Command, svc internal.AllServices, args []string) (out 
 	return
 }
 
-func execute(command Command, svc internal.AllServices, config *config.Config, args []string, parallelRuns int, executeCommand func(exec Executor, arg string) (output.Output, error)) error {
+func execute(command Command, svc internal.AllServices, config *config.Config, args []string, parallelRuns int, executeCommand func(exec Executor, arg string) (output.Output, error)) ([]executeResult, error) {
 	executor := NewExecutor(config, svc)
 	resolvedArgs, err := resolveArguments(command, svc, args)
 	if err != nil {
-		return fmt.Errorf("cannot create resolver: %w", err)
+		return nil, fmt.Errorf("cannot create resolver: %w", err)
 	}
 
 	returnChan := make(chan executeResult)
@@ -133,7 +139,7 @@ func execute(command Command, svc internal.AllServices, config *config.Config, a
 			if len(results) >= len(args) {
 				// we're done, update ui for the last time and render the results
 				executor.Update()
-				return render(config, results)
+				return results, nil
 			}
 		case <-renderTicker.C:
 			executor.Update()

--- a/internal/commands/runcommand_test.go
+++ b/internal/commands/runcommand_test.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"bytes"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"io"
+	"os"
+	"testing"
+)
+
+type mockNone struct {
+	*cobra.Command
+	mock.Mock
+}
+
+func (m *mockNone) InitCommand() {
+	panic("implement me")
+}
+
+func (m *mockNone) Cobra() *cobra.Command {
+	return m.Command
+}
+
+func (m *mockNone) ExecuteWithoutArguments(exec Executor) (output.Output, error) {
+	args := m.Called(exec)
+	return args.Get(0).(output.Output), args.Error(1)
+}
+
+func TestRunCommand(t *testing.T) {
+	var mockNoArgs = &mockNone{Command: &cobra.Command{}}
+	mockNoArgs.On("ExecuteWithoutArguments", mock.Anything).Return(output.OnlyMarshaled{Value: "mock"}, nil)
+	mService := &smock.Service{}
+	cfg := config.New()
+	cfg.Viper().Set(config.KeyOutput, config.ValueOutputJSON)
+	// capture stdout
+	oldStdOut := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// run
+	err := commandRunE(mockNoArgs, mService, cfg, []string{})
+	assert.NoError(t, err)
+	mockNoArgs.AssertNumberOfCalls(t, "ExecuteWithoutArguments", 1)
+
+	os.Stdout = oldStdOut
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+
+	// validate stdout
+	// TODO: this prooobably should be made a bit nicer as well?
+	assert.Equal(t, "\"mock\"\n", buf.String())
+}

--- a/internal/commands/runcommand_test.go
+++ b/internal/commands/runcommand_test.go
@@ -2,9 +2,12 @@ package commands
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -31,33 +34,230 @@ func (m *mockNone) ExecuteWithoutArguments(exec Executor) (output.Output, error)
 	return args.Get(0).(output.Output), args.Error(1)
 }
 
+type mockSingle struct {
+	*cobra.Command
+	mock.Mock
+}
+
+func (m *mockSingle) InitCommand() {
+	panic("implement me")
+}
+
+func (m *mockSingle) Cobra() *cobra.Command {
+	return m.Command
+}
+
+func (m *mockSingle) ExecuteSingleArgument(exec Executor, arg string) (output.Output, error) {
+	args := m.Called(exec, arg)
+	return args.Get(0).(output.Output), args.Error(1)
+}
+
+type mockMulti struct {
+	*cobra.Command
+	mock.Mock
+}
+
+func (m *mockMulti) MaximumExecutions() int {
+	return 10
+}
+
+func (m *mockMulti) InitCommand() {
+	panic("implement me")
+}
+
+func (m *mockMulti) Cobra() *cobra.Command {
+	return m.Command
+}
+
+func (m *mockMulti) Execute(exec Executor, arg string) (output.Output, error) {
+	args := m.Called(exec, arg)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(output.Output), args.Error(1)
+}
+
+type mockMultiResolver struct {
+	*cobra.Command
+	mock.Mock
+}
+
+func (m *mockMultiResolver) Get(_ internal.AllServices) (resolver.Resolver, error) {
+	return func(arg string) (uuid string, err error) {
+		if len(arg) > 5 {
+			return "", fmt.Errorf("MOCKTOOLONG")
+		}
+		return fmt.Sprintf("uuid:%s", arg), nil
+	}, nil
+}
+
+func (m *mockMultiResolver) PositionalArgumentHelp() string {
+	return "MOCKARG"
+}
+
+func (m *mockMultiResolver) MaximumExecutions() int {
+	return 10
+}
+
+func (m *mockMultiResolver) InitCommand() {
+	panic("implement me")
+}
+
+func (m *mockMultiResolver) Cobra() *cobra.Command {
+	return m.Command
+}
+
+func (m *mockMultiResolver) Execute(exec Executor, arg string) (output.Output, error) {
+	args := m.Called(exec, arg)
+	return args.Get(0).(output.Output), args.Error(1)
+}
+
 func TestRunCommand(t *testing.T) {
-	var mockNoArgs = &mockNone{Command: &cobra.Command{}}
-	mockNoArgs.On("ExecuteWithoutArguments", mock.Anything).Return(output.OnlyMarshaled{Value: "mock"}, nil)
+	for _, test := range []struct {
+		name             string
+		args             []string
+		command          Command
+		expectedResult   string
+		expectedRunError string
+	}{
+		{
+			name:           "no args",
+			args:           []string{},
+			command:        &mockNone{Command: &cobra.Command{}},
+			expectedResult: "\"mock\"\n",
+		},
+		{
+			name:           "no args with args should ignore arguments",
+			args:           []string{"goo"},
+			command:        &mockNone{Command: &cobra.Command{}},
+			expectedResult: "\"mock\"\n",
+		},
+		{
+			name:           "single arg",
+			args:           []string{"hello"},
+			command:        &mockSingle{Command: &cobra.Command{}},
+			expectedResult: "\"mock\"\n",
+		},
+		{
+			name:             "single arg with no args",
+			args:             []string{},
+			command:          &mockSingle{Command: &cobra.Command{}},
+			expectedRunError: "exactly 1 argument is required",
+		},
+		{
+			name:           "multi args",
+			args:           []string{"foo", "bar"},
+			command:        &mockMulti{Command: &cobra.Command{}},
+			expectedResult: "[\n  \"mock\",\n  \"mock\"\n]\n",
+		},
+		{
+			name:             "multiarg with no args",
+			args:             []string{},
+			command:          &mockMulti{Command: &cobra.Command{}},
+			expectedRunError: "at least one argument is required",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			switch test.command.(type) {
+			case NoArgumentCommand:
+				test.command.(*mockNone).On("ExecuteWithoutArguments", mock.Anything).Return(output.OnlyMarshaled{Value: "mock"}, nil)
+			case SingleArgumentCommand:
+				test.command.(*mockSingle).On("ExecuteSingleArgument", mock.Anything, mock.Anything).Return(output.OnlyMarshaled{Value: "mock"}, nil)
+			case MultipleArgumentCommand:
+				test.command.(*mockMulti).On("Execute", mock.Anything, mock.Anything).Return(output.OnlyMarshaled{Value: "mock"}, nil)
+			}
+			mService := &smock.Service{}
+			cfg := config.New()
+			cfg.Viper().Set(config.KeyOutput, config.ValueOutputJSON)
+			// capture stdout
+			oldStdOut := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			// run
+			err := commandRunE(test.command, mService, cfg, test.args)
+			if test.expectedRunError == "" {
+				assert.NoError(t, err)
+				switch test.command.(type) {
+				case NoArgumentCommand:
+					test.command.(*mockNone).AssertNumberOfCalls(t, "ExecuteWithoutArguments", 1)
+				case SingleArgumentCommand:
+					test.command.(*mockSingle).AssertNumberOfCalls(t, "ExecuteSingleArgument", 1)
+				case MultipleArgumentCommand:
+					test.command.(*mockMulti).AssertNumberOfCalls(t, "Execute", len(test.args))
+				}
+			} else {
+				assert.EqualError(t, err, test.expectedRunError)
+			}
+
+			os.Stdout = oldStdOut
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			if test.expectedResult != "" {
+				var buf bytes.Buffer
+				if _, err := io.Copy(&buf, r); err != nil {
+					t.Fatal(err)
+				}
+				// validate stdout
+				assert.Equal(t, test.expectedResult, buf.String())
+			}
+		})
+	}
+}
+
+func TestExecute_Resolution(t *testing.T) {
+	cmd := &mockMultiResolver{Command: &cobra.Command{}}
 	mService := &smock.Service{}
 	cfg := config.New()
 	cfg.Viper().Set(config.KeyOutput, config.ValueOutputJSON)
-	// capture stdout
-	oldStdOut := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	// run
-	err := commandRunE(mockNoArgs, mService, cfg, []string{})
+	executor := NewExecutor(cfg, mService)
+	results, err := execute(cmd, executor, []string{"a", "b", "failtoresolve", "c"}, 10, func(exec Executor, arg string) (output.Output, error) {
+		return output.OnlyMarshaled{Value: arg}, nil
+	})
+	assert.Len(t, results, 4)
 	assert.NoError(t, err)
-	mockNoArgs.AssertNumberOfCalls(t, "ExecuteWithoutArguments", 1)
 
-	os.Stdout = oldStdOut
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
+	// as results are run in parallel, they dont always come out in the same order.
+	values := map[string]struct{}{}
+	for _, r := range results {
+		if r.Error == nil {
+			values[r.Result.(output.OnlyMarshaled).Value.(string)] = struct{}{}
+		} else {
+			assert.Nil(t, r.Result)
+			assert.EqualError(t, r.Error, "cannot resolve argument: MOCKTOOLONG")
+		}
 	}
+	assert.Equal(t, values, map[string]struct{}{
+		"uuid:a": {},
+		"uuid:b": {},
+		"uuid:c": {},
+	})
+}
 
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		t.Fatal(err)
+func TestExecute_Error(t *testing.T) {
+	cmd := &mockMulti{Command: &cobra.Command{}}
+	cmd.On("Execute", mock.Anything, mock.MatchedBy(func(arg string) bool {
+		return len(arg) < 5
+	})).Return(output.OnlyMarshaled{Value: "mock"}, nil)
+	cmd.On("Execute", mock.Anything, mock.MatchedBy(func(arg string) bool {
+		return len(arg) >= 5
+	})).Return(nil, fmt.Errorf("MOCKKFFAIL"))
+	mService := &smock.Service{}
+	cfg := config.New()
+	cfg.Viper().Set(config.KeyOutput, config.ValueOutputJSON)
+	executor := NewExecutor(cfg, mService)
+	results, err := execute(cmd, executor, []string{"a", "b", "failtorexecute", "c"}, 10, cmd.Execute)
+	assert.Len(t, results, 4)
+	assert.NoError(t, err)
+
+	for _, r := range results {
+		if r.Error == nil {
+			assert.Equal(t, output.OnlyMarshaled{Value: "mock"}, r.Result)
+		} else {
+			assert.Nil(t, r.Result)
+			assert.EqualError(t, r.Error, "MOCKKFFAIL")
+		}
 	}
-
-	// validate stdout
-	// TODO: this prooobably should be made a bit nicer as well?
-	assert.Equal(t, "\"mock\"\n", buf.String())
 }


### PR DESCRIPTION
Separate more bits out of the runcommand internals; move render to be called by runcommandE and move executor creation to runcommandE, as well. This is in order to separate the concerns better and make the separate bits more testable. 