### PR TITLE
fix(client-timeout): change default timeout to no timeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,14 +191,18 @@ func (s *Config) CreateService() (internal.AllServices, error) {
 		return nil, fmt.Errorf("user credentials not found, these must be set in config file (%s) or via environment variables", configDetails)
 	}
 
-	hc := &http.Client{Transport: &transport{}}
-	hc.Timeout = s.ClientTimeout()
-
+	hc := &http.Client{Transport: &transport{}, Timeout: s.ClientTimeout()}
 	whc := client.NewWithHTTPClient(
 		username,
 		password,
 		hc,
 	)
+	// TODO: remove this after go-api actually respects 0 timeout
+	// this is in order to enforce our custom (no) timeout because currently go-api
+	// assumes 0 timeout means 'not set' rather than 'no timeout'.
+	// see https://github.com/UpCloudLtd/upcloud-go-api/blob/2964ed7e597209b50a21f34259a20249e9aa220c/upcloud/client/client.go#L48
+	hc.Timeout = s.ClientTimeout()
+
 	whc.UserAgent = fmt.Sprintf("upctl/%s", Version)
 	svc := service.New(whc)
 	// TODO; remove this when refactor is complete

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/all"
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
@@ -60,7 +58,7 @@ func BuildRootCmd(conf *config.Config) cobra.Command {
 	)
 	flags.DurationVarP(
 		&conf.GlobalFlags.ClientTimeout, "client-timeout", "t",
-		time.Duration(60*time.Second),
+		0,
 		"CLI timeout when using interactive mode on some commands",
 	)
 


### PR DESCRIPTION
This has been discussed before (Slack link below) and after some more thinking (wrt storage import), it seems like there really is no reason to have any sort of a default timeout in the client. 

Our backend and load balancers already enforce timeouts on the backend side and there seems to be no benefit in timing out a client request in the client end, as that will only throw errors to the users that don't really convey any useful information and will (most likely) just encourage the user to try again with a higher timeout until giving up. Hanging, on the other hand, indicates that something is wrong and requires the user to interrupt the operation manually.

In particular, local file storage imports can easily go over any sensible timeouts so the other option to support it would be to have per-command timeouts, which seems quite unnecessary and opaque, eg. confusing to the user. 

Ref: https://upcloud.slack.com/archives/C01MSUTR6PL/p1617269550033700