### PR TITLE
feat: implement initial terminal width support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/sys v0.0.0-20210301091718-77cc2087c03b // indirect
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/internal/commands/executor.go
+++ b/internal/commands/executor.go
@@ -18,6 +18,7 @@ import (
 type Executor interface {
 	NewLogEntry(s string) *ui.LogEntry
 	Update()
+	Close()
 	WaitFor(waitFn func() error, timeout time.Duration) error
 	Server() service.Server
 	Storage() service.Storage
@@ -76,6 +77,11 @@ func (e *executorImpl) NewLogEntry(message string) *ui.LogEntry {
 // Update implements Executor
 func (e *executorImpl) Update() {
 	e.LiveLog.Render()
+}
+
+// Close implements Executor
+func (e *executorImpl) Close() {
+	e.LiveLog.Close()
 }
 
 func (e executorImpl) Server() service.Server {

--- a/internal/commands/runcommand.go
+++ b/internal/commands/runcommand.go
@@ -20,6 +20,7 @@ var (
 func commandRunE(command Command, service internal.AllServices, config *config.Config, args []string) error {
 	cmdLogger := logger.With("command", command.Cobra().CommandPath())
 	executor := NewExecutor(config, service, cmdLogger)
+	defer executor.Close()
 	switch typedCommand := command.(type) {
 	case NoArgumentCommand:
 		cmdLogger.Debug("executing without arguments", "arguments", args)

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 	"gopkg.in/yaml.v2"
 
-	"github.com/UpCloudLtd/upcloud-cli/internal/terminal"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-cli/internal/validation"
 )
@@ -69,7 +68,6 @@ func (s Table) MarshalHuman() ([]byte, error) {
 	t.ResetFooters()
 	t.ResetRows()
 	t.SetStyle(defaultTableStyle)
-	t.SetAllowedRowLength(terminal.GetTerminalWidth())
 	/*
 		// TODO: reimplement this if/when necessary
 		if len(s.overrideColumnKeys) > 0 {

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 	"gopkg.in/yaml.v2"
 
+	"github.com/UpCloudLtd/upcloud-cli/internal/terminal"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-cli/internal/validation"
 )

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -68,6 +68,7 @@ func (s Table) MarshalHuman() ([]byte, error) {
 	t.ResetFooters()
 	t.ResetRows()
 	t.SetStyle(defaultTableStyle)
+	t.SetAllowedRowLength(terminal.GetTerminalWidth())
 	/*
 		// TODO: reimplement this if/when necessary
 		if len(s.overrideColumnKeys) > 0 {

--- a/internal/terminal/resizeevents.go
+++ b/internal/terminal/resizeevents.go
@@ -1,0 +1,36 @@
+// +build linux darwin
+
+package terminal
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// ResizeListener calls given callback function when terminal window is resized.
+// This is currently a no-op in Windows.
+type ResizeListener struct {
+	signal chan os.Signal
+}
+
+// NewResizeListener creates a new ResizeListener
+func NewResizeListener(callback func()) *ResizeListener {
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGWINCH)
+	go func() {
+		for range signalCh {
+			callback()
+		}
+	}()
+	return &ResizeListener{
+		signal: signalCh,
+	}
+}
+
+// Close stops ResizeListener listening and cleans up associated resources
+func (s *ResizeListener) Close() {
+	signal.Stop(s.signal)
+	close(s.signal)
+
+}

--- a/internal/terminal/resizeevents_windows.go
+++ b/internal/terminal/resizeevents_windows.go
@@ -1,0 +1,15 @@
+package terminal
+
+// ResizeListener calls given callback function when terminal window is resized.
+// This is currently a no-op in Windows.
+type ResizeListener struct {
+}
+
+// NewResizeListener creates a new ResizeListener
+func NewResizeListener(_ func()) *ResizeListener {
+	return &ResizeListener{}
+}
+
+// Close stops ResizeListener listening and cleans up associated resources
+func (s *ResizeListener) Close() {
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/mattn/go-isatty"
+	"golang.org/x/term"
 )
 
 var (
@@ -24,4 +25,14 @@ func IsStdoutTerminal() bool {
 // IsStderrTerminal returns true if the terminal is stderr
 func IsStderrTerminal() bool {
 	return isStderrTerminal
+}
+
+// GetTerminalWidth tries to figure out the width of the terminal and returns it
+// returns 0 if there are problems in getting the width.
+func GetTerminalWidth() int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return 0
+	}
+	return w
 }

--- a/internal/ui/details.go
+++ b/internal/ui/details.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"github.com/UpCloudLtd/upcloud-cli/internal/terminal"
+
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 )
@@ -72,7 +74,7 @@ func (s *DetailsView) Render() string {
 	if s.headerWidth == 0 {
 		s.headerWidth = headerMaxWidth
 	}
-	widthRemaining := 140
+	widthRemaining := terminal.GetTerminalWidth()
 	var colConfigs []table.ColumnConfig
 	for i := range s.rows[0] {
 		if i < len(s.rows[0])-1 {

--- a/internal/ui/log.go
+++ b/internal/ui/log.go
@@ -21,7 +21,7 @@ var (
 	}
 	// LiveLogDefaultConfig represents the default settings for live log
 	LiveLogDefaultConfig = LiveLogConfig{
-		EntryMaxWidth:        80,
+		EntryMaxWidth:        terminal.GetTerminalWidth(),
 		renderPending:        true,
 		DisableLiveRendering: !terminal.IsStdoutTerminal(),
 		Colours:              liveLogDefaultColours,
@@ -186,7 +186,7 @@ func (s *LiveLog) renderEntry(entry *LogEntry) {
 	if text.RuneCount(msg) > s.config.EntryMaxWidth {
 		msg = fmt.Sprintf("%s...", text.Trim(msg, s.config.EntryMaxWidth-3))
 	}
-	msg = text.Pad(msg, s.config.EntryMaxWidth, ' ')
+	msg = text.Pad(msg, s.config.EntryMaxWidth-len(durStr)-1, ' ')
 	s.write(colours.Sprint(msg))
 	s.write(s.config.Colours.Time.Sprint(durStr))
 	s.write("\n")


### PR DESCRIPTION
- add terminal width detection 
- set up livelog rendering to respect terminal width and handle resize events (not on Windows)

Initially, the aim was to add terminal width support to table rendering as well, but it's not clear how we should handle that case as when the table does not fit, truncating the table does not seem like a good idea and when it's too small, the library used does not really give us easy ways of fitting to available width.

Thus, we just render tables like we used to - at the minimum width that we can fit the table into without truncating values.