### PR TITLE
fix(network/router): implement router attaching and detaching with new go-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/UpCloudLtd/upcloud-cli
 go 1.13
 
 require (
-	github.com/UpCloudLtd/upcloud-go-api v0.0.0-20201130170350-7fc02444127a
+	github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210525102709-661419a1956b
 	github.com/adrg/xdg v0.3.2
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/UpCloudLtd/upcloud-go-api v0.0.0-20201130170350-7fc02444127a h1:9dQjUEQKfRIuVAaDjWOfyjpydGPTq/MjJTuyBjVH7go=
-github.com/UpCloudLtd/upcloud-go-api v0.0.0-20201130170350-7fc02444127a/go.mod h1:nKv1Y0cTJTGYSd3lEcFfEnbPPiIj3gT4lJzV0ZfTlpQ=
+github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210525102709-661419a1956b h1:WDp7g7xKKvXJvfEPicT8A7dLwMDgEN5cb5fgnsgvzJw=
+github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210525102709-661419a1956b/go.mod h1:nKv1Y0cTJTGYSd3lEcFfEnbPPiIj3gT4lJzV0ZfTlpQ=
 github.com/adrg/xdg v0.3.2 h1:GUSGQ5pHdev83AYhDSS1A/CX+0JIsxbiWtow2DSA+RU=
 github.com/adrg/xdg v0.3.2/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/commands/network/modify.go
+++ b/internal/commands/network/modify.go
@@ -43,8 +43,8 @@ func ModifyCommand() commands.Command {
 func (s *modifyCommand) InitCommand() {
 	fs := &pflag.FlagSet{}
 	fs.StringVar(&s.name, "name", "", "Set name of the private network.")
-	fs.StringVar(&s.attachRouter, "router", "", "Set the router attachment.")
-	config.AddToggleFlag(fs, &s.detachRouter, "detach-router", false, "Detach the router attachment.")
+	fs.StringVar(&s.attachRouter, "router", "", "Attach a router to this network, specified by router UUID or router name.")
+	config.AddToggleFlag(fs, &s.detachRouter, "detach-router", false, "Detach a router from this network.")
 	fs.StringArrayVar(&s.networks, "ip-network", s.networks, "The ip network with modified values. \n\n"+
 		"Fields \n"+
 		"  family: string \n"+

--- a/internal/commands/network/modify.go
+++ b/internal/commands/network/modify.go
@@ -3,23 +3,28 @@ package network
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
-	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
-	"github.com/UpCloudLtd/upcloud-cli/internal/output"
-	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/spf13/pflag"
+
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 )
 
 type modifyCommand struct {
 	*commands.BaseCommand
-	networks []string
-	router   string
-	name     string
+	networks     []string
+	attachRouter string
+	name         string
+	detachRouter config.OptionalBoolean
 	completion.Network
 	resolver.CachingNetwork
+	// routerResolver is used to support resolving names of routers to uuids
+	routerResolver resolver.CachingRouter
 }
 
 // ModifyCommand creates the "network modify" command
@@ -38,7 +43,8 @@ func ModifyCommand() commands.Command {
 func (s *modifyCommand) InitCommand() {
 	fs := &pflag.FlagSet{}
 	fs.StringVar(&s.name, "name", "", "Set name of the private network.")
-	fs.StringVar(&s.router, "router", "", "Change or clear the router attachment.")
+	fs.StringVar(&s.attachRouter, "router", "", "Set the router attachment.")
+	config.AddToggleFlag(fs, &s.detachRouter, "detach-router", false, "Detach the router attachment.")
 	fs.StringArrayVar(&s.networks, "ip-network", s.networks, "The ip network with modified values. \n\n"+
 		"Fields \n"+
 		"  family: string \n"+
@@ -51,6 +57,9 @@ func (s *modifyCommand) InitCommand() {
 
 // ExecuteSingleArgument implements commands.SingleArgumentCommand
 func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string) (output.Output, error) {
+	if s.attachRouter != "" && s.detachRouter == config.True {
+		return nil, fmt.Errorf("ambiguous command, cannot detach and attach a router at the same time")
+	}
 	var networks []upcloud.IPNetwork
 	for _, networkStr := range s.networks {
 		network, err := handleNetwork(networkStr)
@@ -68,21 +77,75 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()
-	logline.SetMessage(fmt.Sprintf("%s: sending request", msg))
 
-	res, err := exec.Network().ModifyNetwork(&request.ModifyNetworkRequest{
-		UUID:       arg,
-		Name:       s.name,
-		Zone:       "", // TODO: should this be implemented?
-		Router:     s.router,
-		IPNetworks: networks,
-	})
-	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+	var network *upcloud.Network
+	if s.name != "" || len(networks) > 0 {
+		// we want to update name and/or networks
+		logline.SetMessage(fmt.Sprintf("%s: sending modify request", msg))
+		res, err := exec.Network().ModifyNetwork(&request.ModifyNetworkRequest{
+			UUID:       arg,
+			Name:       s.name,
+			Zone:       "", // TODO: should this be implemented?
+			IPNetworks: networks,
+		})
+		if err != nil {
+			logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
+			logline.SetDetails(err.Error(), "error: ")
+			return nil, err
+		}
+		// store the result in order to return it
+		network = res
 	}
+
+	if s.attachRouter != "" {
+		routerResolver, err := s.routerResolver.Get(exec.All())
+		if err != nil {
+			return nil, fmt.Errorf("cannot get router resolver: %w", err)
+		}
+		routerUUID, err := routerResolver(s.attachRouter)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get resolve router '%s': %w", s.attachRouter, err)
+		}
+		logline.SetMessage(fmt.Sprintf("%s: attaching router %s", msg, routerUUID))
+		logline.SetDetails(routerUUID, "router UUID: ")
+		err = exec.Network().AttachNetworkRouter(&request.AttachNetworkRouterRequest{
+			NetworkUUID: arg,
+			RouterUUID:  routerUUID,
+		})
+		if err != nil {
+			logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
+			logline.SetDetails(err.Error(), "error: ")
+			return nil, fmt.Errorf("cannot attach router '%s': %w", s.attachRouter, err)
+		}
+		// update the stored result (if we have one) manually to avoid refetching later
+		if network != nil {
+			network.Router = routerUUID
+		}
+	} else if s.detachRouter == config.True {
+		logline.SetMessage(fmt.Sprintf("%s: detaching router", msg))
+		err := exec.Network().DetachNetworkRouter(&request.DetachNetworkRouterRequest{
+			NetworkUUID: arg,
+		})
+		if err != nil {
+			logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
+			logline.SetDetails(err.Error(), "error: ")
+			return nil, fmt.Errorf("cannot detach router '%s': %w", s.attachRouter, err)
+		}
+		// update the stored result (if we have one) manually to avoid refetching later
+		if network != nil {
+			network.Router = ""
+		}
+	}
+
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
-	return output.OnlyMarshaled{Value: res}, nil
+	if network == nil {
+		// if we're just detaching/attaching, we won't have network returned from the calls so re-fetch
+		details, err := exec.Network().GetNetworkDetails(&request.GetNetworkDetailsRequest{UUID: arg})
+		if err != nil {
+			return nil, fmt.Errorf("cannot get network state: %w", err)
+		}
+		network = details
+	}
+	return output.OnlyMarshaled{Value: network}, nil
 }

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -359,6 +359,18 @@ func (m *Service) ModifyNetwork(r *request.ModifyNetworkRequest) (*upcloud.Netwo
 	return args[0].(*upcloud.Network), args.Error(1)
 }
 
+// AttachNetworkRouter implements service.Network.AttachNetworkRouter
+func (m *Service) AttachNetworkRouter(r *request.AttachNetworkRouterRequest) error {
+	args := m.Called(r)
+	return args.Error(0)
+}
+
+// DetachNetworkRouter implements service.Network.DetachNetworkRouter
+func (m *Service) DetachNetworkRouter(r *request.DetachNetworkRouterRequest) error {
+	args := m.Called(r)
+	return args.Error(0)
+}
+
 // GetServerNetworks implements service.Network.GetServerNetworks
 func (m *Service) GetServerNetworks(r *request.GetServerNetworksRequest) (*upcloud.Networking, error) {
 	args := m.Called(r)

--- a/internal/terminal/resizeevents.go
+++ b/internal/terminal/resizeevents.go
@@ -32,5 +32,4 @@ func NewResizeListener(callback func()) *ResizeListener {
 func (s *ResizeListener) Close() {
 	signal.Stop(s.signal)
 	close(s.signal)
-
 }


### PR DESCRIPTION
- adds a `--detach-router` toggle flag to `network modify`, that triggers a detach
- changes `--router` to only work for attaching, eg. one can't detach with `--router ""` anymore. (nb. due to the go-api issue, it didnt work before)

Considered adding separate commands for detaching and attaching, but did not like the approach as `network detachrouter` is a bit clunky? Other suggestions for improving/changing UI are welcome.