### PR TITLE
feat(server): parity between server create and network-interface create commands

### DIFF
--- a/internal/commands/networkinterface/create_test.go
+++ b/internal/commands/networkinterface/create_test.go
@@ -52,14 +52,6 @@ func TestCreateCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "ip-family unsupported for private network",
-			flags: []string{
-				"--network", network.UUID,
-				"--family", "IPv6",
-			},
-			error: "Currently only IPv4 is supported in private networks",
-		},
-		{
 			name: "set ip-family for public network",
 			flags: []string{
 				"--family", "IPv6",
@@ -102,13 +94,13 @@ func TestCreateCommand(t *testing.T) {
 				"--network", network.UUID,
 				"--ip-addresses", "127.0.0.1,127.0.0.2,127.0.0.3/22",
 				"--enable-bootable",
-				"--enable-source-ip-filtering",
+				"--disable-source-ip-filtering",
 				"--index", "4",
 			},
 			req: request.CreateNetworkInterfaceRequest{
 				ServerUUID:        server.UUID,
 				Bootable:          upcloud.True,
-				SourceIPFiltering: upcloud.True,
+				SourceIPFiltering: upcloud.False,
 				NetworkUUID:       network.UUID,
 				IPAddresses: request.CreateNetworkInterfaceIPAddressSlice{
 					{Address: "127.0.0.1", Family: upcloud.IPAddressFamilyIPv4},

--- a/internal/config/optionalboolean.go
+++ b/internal/config/optionalboolean.go
@@ -25,7 +25,9 @@ const (
 	FalseFlagValue = "false"
 	// TrueFlagValue true Bool String value
 	TrueFlagValue = "true"
+)
 
+const (
 	// Unset is the OptionalBoolean value representing not set
 	Unset OptionalBoolean = iota // 0
 	// True is the OptionalBoolean value representing true

--- a/internal/config/optionalboolean_test.go
+++ b/internal/config/optionalboolean_test.go
@@ -37,7 +37,7 @@ func TestSetBoolFlag_EnableDisableFlags(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			fs := &pflag.FlagSet{}
-			target := Unset
+			var target OptionalBoolean
 			AddEnableDisableFlags(fs, &target, "test", "testing")
 			err := fs.Parse(test.args)
 			if test.expectedError == "" {


### PR DESCRIPTION
* Support all network interface related attributes during server create.
  Before this, a private interface couldn't be created as the network
  couldn't be provided.
* Use `AddEnableDisableFlags` for bootable and source ip filtering in both
  command contexts. This is to allow user to explicitly declare the intent
  regardless of the API's defaults.
* Remove check for supported families per interface type from
  `network-interface create` command. The limitation is a "soft" one and will
  probably change. It is better to let the API handle this kind of validation.
* Remove `network` context check from `network-interface create` command.
  It is supported to specify address with public and utility type of
  interfaces for instance with private clouds.