### PR TITLE
Default to not create a password, but do so when password delivery method is chosen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change password creation to be disabled by default in server creation
+- Always create a password when password delivery method is chosen
 
 ## [1.1.0] - 2021-06-03
 ### Added

--- a/internal/commands/networkinterface/modify.go
+++ b/internal/commands/networkinterface/modify.go
@@ -64,8 +64,8 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 	}
 	// initialize bootable and filtering flags as empty
 	var empty = upcloud.Empty
-	var bootable *upcloud.Boolean = &empty
-	var sourceIPFiltering *upcloud.Boolean = &empty
+	var bootable = &empty
+	var sourceIPFiltering = &empty
 	if s.bootable != "" {
 		bootable, err = commands.BoolFromString(s.bootable)
 		if err != nil {

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -51,7 +51,7 @@ var defaultCreateParams = &createParams{
 	osStorageSize:  0,
 	sshKeys:        nil,
 	username:       "",
-	createPassword: true,
+	createPassword: false,
 }
 
 type createParams struct {
@@ -288,6 +288,10 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	}
 	if s.params.os == defaultCreateParams.os && s.params.PasswordDelivery == "none" && s.params.sshKeys == nil {
 		return nil, fmt.Errorf("a password-delivery method, ssh-keys or a custom image must be specified")
+	}
+
+	if !s.createPassword.Value() && s.params.PasswordDelivery != "none" {
+		_ = s.createPassword.Set("true")
 	}
 
 	if s.params.Title == "" {

--- a/internal/commands/server/create_test.go
+++ b/internal/commands/server/create_test.go
@@ -132,6 +132,7 @@ func TestCreateServer(t *testing.T) {
 				"--zone", "uk-lon1",
 				"--os", Storage1.UUID,
 				"--os-storage-size", "100",
+				"--password-delivery", "email",
 			},
 			createServerReq: request.CreateServerRequest{
 				VideoModel:       "vga",
@@ -140,7 +141,7 @@ func TestCreateServer(t *testing.T) {
 				Hostname:         "example.com",
 				Title:            "test-server",
 				Zone:             "uk-lon1",
-				PasswordDelivery: "none",
+				PasswordDelivery: "email",
 				LoginUser:        &request.LoginUser{CreatePassword: "yes"},
 				StorageDevices: request.CreateServerStorageDeviceSlice{request.CreateServerStorageDevice{
 					Action:  "clone",

--- a/internal/terminal/resizeevents.go
+++ b/internal/terminal/resizeevents.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || freebsd
 // +build linux darwin freebsd
 
 package terminal


### PR DESCRIPTION
This PR will fix #97 and also address the previous insecure default of creating a password for servers. After this PR is accepted, a new version (1.1.1?) of upctl should be created.

In relation to the new [one-time password policy](https://developers.upcloud.com/1.3/8-servers/#creating-from-a-template), all deployments with both SSH keys and passwords are rejected due to the fact that one-time password would prompt for a password change for SSH logins as well, leaving the user in a nasty situation.

This PR will:
- Change the default to not creating a password
- Always creating a password when password delivery method is chosen, even if --create-password is not specified