### PR TITLE
fix: storage command attached-to-server key overrides zone

### DIFF
--- a/internal/commands/storage/show.go
+++ b/internal/commands/storage/show.go
@@ -63,7 +63,7 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 						{Title: "Size:", Key: "size", Value: storage.Size},
 						{Title: "Tier:", Key: "tier", Value: storage.Tier},
 						{Title: "Zone:", Key: "zone", Value: storage.Zone},
-						{Title: "Server:", Key: "zone", Value: attachedToServer},
+						{Title: "Server:", Key: "server", Value: attachedToServer},
 						{Title: "Origin:", Key: "origin", Value: storage.Origin, Colour: ui.DefaultUUUIDColours},
 						{Title: "Created:", Key: "created", Value: storage.Created},
 						{Title: "Licence:", Key: "licence", Value: storage.License},


### PR DESCRIPTION
Storage command output has a duplicate output key "zone" used for both storage Zone and attachedToServer field,
so the server ends up in the zone field and the actual zone information is overwritten.

JSON output before:

{
  ...
  "zone": "00088baf-d71c-4dd3-9b53-deadbabe"
}

JSON output after:

{
  "server": "00088baf-d71c-4dd3-9b53-deadbabe",
  "zone": "fi-hel2"
}