### PR TITLE
fix(resolver): clarify error messages relating to argument resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Improved errors relating to argument resolver failures
 
 ## [1.1.3] - 2022-02-24
 ### Changed

--- a/internal/commands/runcommand.go
+++ b/internal/commands/runcommand.go
@@ -85,7 +85,7 @@ func resolveArguments(nc Command, svc internal.AllServices, args []string) (out 
 	if resolve, ok := nc.(resolver.ResolutionProvider); ok {
 		argumentResolver, err := resolve.Get(svc)
 		if err != nil {
-			return nil, fmt.Errorf("cannot create resolver: %w", err)
+			return nil, fmt.Errorf("cannot get resolver: %w", err)
 		}
 		for _, arg := range args {
 			resolved, err := argumentResolver(arg)
@@ -102,7 +102,7 @@ func resolveArguments(nc Command, svc internal.AllServices, args []string) (out 
 func execute(command Command, executor Executor, args []string, parallelRuns int, executeCommand func(exec Executor, arg string) (output.Output, error)) ([]executeResult, error) {
 	resolvedArgs, err := resolveArguments(command, executor.All(), args)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create resolver: %w", err)
+		return nil, fmt.Errorf("cannot resolve command line arguments: %w", err)
 	}
 
 	returnChan := make(chan executeResult)


### PR DESCRIPTION
Previously, resolver failing (which can happen on backend failure, for example) would result in a stuttering error message:
```
cannot create resolver: cannot create resolver: ...
```
which also seems to indicate that it's a DNS issue which is problematic as the upctl internal use of 'resolver' refers to *argument* resolution rather than name resolution. This PR changes the error messages and the above error would look like:
```
cannot resolve command line arguments: cannot get resolver: ...
```
