### PR TITLE
Do not create API client for offline commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Improved errors relating to argument resolver failures
+- Print version info, instead of missing credentials error, when runnning `upctl version` without credentials
 
 ## [1.1.3] - 2022-02-24
 ### Changed

--- a/internal/commands/root/completion.go
+++ b/internal/commands/root/completion.go
@@ -26,3 +26,6 @@ func (s *CompletionCommand) ExecuteSingleArgument(_ commands.Executor, arg strin
 
 	return nil, fmt.Errorf("completion for %s is not supported", arg)
 }
+
+// DoesNotUseServices implements commands.OfflineCommand as this command does not use services
+func (s *CompletionCommand) DoesNotUseServices() {}

--- a/internal/commands/root/version.go
+++ b/internal/commands/root/version.go
@@ -17,10 +17,13 @@ type VersionCommand struct {
 func (s *VersionCommand) ExecuteWithoutArguments(_ commands.Executor) (output.Output, error) {
 	return output.Details{Sections: []output.DetailSection{
 		{Rows: []output.DetailRow{
-			{Title: "Version", Key: "version", Value: config.Version},
+			{Title: "Version:", Key: "version", Value: config.Version},
 			{Title: "Build date:", Key: "build_date", Value: config.BuildDate},
 			{Title: "Built with:", Key: "built_with", Value: runtime.Version()},
 		},
 		}},
 	}, nil
 }
+
+// DoesNotUseServices implements commands.OfflineCommand as this command does not use services
+func (s *VersionCommand) DoesNotUseServices() {}

--- a/internal/commands/runcommand_test.go
+++ b/internal/commands/runcommand_test.go
@@ -210,6 +210,17 @@ func TestRunCommand(t *testing.T) {
 	}
 }
 
+func TestExecute_Offline(t *testing.T) {
+	cmd := &mockNone{Command: &cobra.Command{}}
+	cmd.On("ExecuteWithoutArguments", mock.Anything).Return(output.OnlyMarshaled{Value: "mock"}, nil)
+
+	cfg := config.New()
+	cfg.Viper().Set(config.KeyOutput, config.ValueOutputJSON)
+
+	err := commandRunE(cmd, nil, cfg, []string{})
+	assert.NoError(t, err)
+}
+
 func TestExecute_Resolution(t *testing.T) {
 	cmd := &mockMultiResolver{Command: &cobra.Command{}}
 	mService := &smock.Service{}


### PR DESCRIPTION
This allows running offline commands, such as upctl version, without having to define credentials.

Fixes #94 