### PR TITLE
Include UUID of created resource in create output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Print version info, instead of missing credentials error, when runnning `upctl version` without credentials
 - Disable colors when outputting in JSON or YAML format
 - Display both public and private addresses in `server create` output
+- Render livelog messages of commands which execution takes less than render tick interval
 
 ## [1.1.3] - 2022-02-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Include UUID (or address) of created resource in create command output
+
 ### Changed
 - New go-api version v4.3.0
 

--- a/internal/commands/ipaddress/assign.go
+++ b/internal/commands/ipaddress/assign.go
@@ -92,5 +92,7 @@ func (s *assignCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	}
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
-	return output.OnlyMarshaled{Value: res}, nil
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "IP Address", Value: res.Address, Colour: ui.DefaultAddressColours},
+	}}, nil
 }

--- a/internal/commands/ipaddress/modify.go
+++ b/internal/commands/ipaddress/modify.go
@@ -51,7 +51,7 @@ func (s *modifyCommand) Execute(exec commands.Executor, arg string) (output.Outp
 	if arg == "" {
 		return nil, errors.New("need ip address to modify")
 	}
-	msg := fmt.Sprintf("modifying ip-address %v", arg)
+	msg := fmt.Sprintf("Modifying ip-address %v", arg)
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()

--- a/internal/commands/ipaddress/remove.go
+++ b/internal/commands/ipaddress/remove.go
@@ -41,7 +41,7 @@ func (s *removeCommand) InitCommand() {
 
 // Execute implements commands.MultipleArgumentCommand
 func (s *removeCommand) Execute(exec commands.Executor, arg string) (output.Output, error) {
-	msg := fmt.Sprintf("removing ip-address %v", arg)
+	msg := fmt.Sprintf("Removing ip-address %v", arg)
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()

--- a/internal/commands/network/create.go
+++ b/internal/commands/network/create.go
@@ -101,7 +101,7 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	}
 	svc := exec.Network()
 
-	msg := fmt.Sprintf("creating network %v", s.name)
+	msg := fmt.Sprintf("Creating network %v", s.name)
 	logline := exec.NewLogEntry(msg)
 	logline.StartedNow()
 

--- a/internal/commands/network/create.go
+++ b/internal/commands/network/create.go
@@ -120,5 +120,7 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	}
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
-	return output.OnlyMarshaled{Value: res}, nil
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "UUID", Value: res.UUID, Colour: ui.DefaultUUUIDColours},
+	}}, nil
 }

--- a/internal/commands/network/delete.go
+++ b/internal/commands/network/delete.go
@@ -37,7 +37,7 @@ func (s *deleteCommand) InitCommand() {
 // Execute implements commands.MultipleArgumentCommand
 func (s *deleteCommand) Execute(exec commands.Executor, arg string) (output.Output, error) {
 	svc := exec.Network()
-	msg := fmt.Sprintf("deleting network %v", arg)
+	msg := fmt.Sprintf("Deleting network %v", arg)
 	logline := exec.NewLogEntry(msg)
 	logline.StartedNow()
 	err := svc.DeleteNetwork(&request.DeleteNetworkRequest{

--- a/internal/commands/router/create.go
+++ b/internal/commands/router/create.go
@@ -59,5 +59,7 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
-	return output.OnlyMarshaled{Value: res}, nil
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "UUID", Value: res.UUID, Colour: ui.DefaultUUUIDColours},
+	}}, nil
 }

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -400,7 +400,7 @@ func formatIPAddresses(val interface{}) (text.Colors, string, error) {
 
 	var strs []string
 	for ipa := range addresses {
-		strs = append(strs, ipa)
+		strs = append(strs, ui.DefaultAddressColours.Sprint(ipa))
 	}
 
 	return nil, strings.Join(strs, ",\n"), nil

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -312,7 +312,7 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	serverSvc := exec.Server()
 	planSvc := exec.Plan()
 	storageSvc := exec.Storage()
-	msg := fmt.Sprintf("creating server %v", s.params.Hostname)
+	msg := fmt.Sprintf("Creating server %v", s.params.Hostname)
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()

--- a/internal/commands/server/delete.go
+++ b/internal/commands/server/delete.go
@@ -44,7 +44,7 @@ func (s *deleteCommand) InitCommand() {
 // Execute implements commands.MultipleArgumentCommand
 func (s *deleteCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
 	svc := exec.Server()
-	msg := fmt.Sprintf("deleting server %v", uuid)
+	msg := fmt.Sprintf("Deleting server %v", uuid)
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()
@@ -68,6 +68,7 @@ func (s *deleteCommand) Execute(exec commands.Executor, uuid string) (output.Out
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
+	logline.MarkDone()
 
 	return output.None{}, nil
 }

--- a/internal/commands/server/modify.go
+++ b/internal/commands/server/modify.go
@@ -98,7 +98,7 @@ func (s *modifyCommand) Execute(exec commands.Executor, uuid string) (output.Out
 		s.params.Plan = "custom" // Valid for all custom plans.
 	}
 
-	msg := fmt.Sprintf("modifying server %v", uuid)
+	msg := fmt.Sprintf("Modifying server %v", uuid)
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()

--- a/internal/commands/server/restart.go
+++ b/internal/commands/server/restart.go
@@ -56,7 +56,7 @@ func (s *restartCommand) MaximumExecutions() int {
 // Execute implements commands.MultipleArgumentCommand
 func (s *restartCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
 	svc := exec.Server()
-	msg := fmt.Sprintf("restarting server %v", uuid)
+	msg := fmt.Sprintf("Restarting server %v", uuid)
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()

--- a/internal/commands/server/start.go
+++ b/internal/commands/server/start.go
@@ -38,7 +38,7 @@ func (s *startCommand) InitCommand() {
 // Execute implements commands.MultipleArgumentCommand
 func (s *startCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
 	svc := exec.Server()
-	msg := fmt.Sprintf("starting server %v", uuid)
+	msg := fmt.Sprintf("Starting server %v", uuid)
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()

--- a/internal/commands/server/stop.go
+++ b/internal/commands/server/stop.go
@@ -44,7 +44,7 @@ func (s *stopCommand) InitCommand() {
 // Execute implements commands.MultipleArgumentCommand
 func (s *stopCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
 	svc := exec.Server()
-	msg := fmt.Sprintf("stopping server %v", uuid)
+	msg := fmt.Sprintf("Stopping server %v", uuid)
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()

--- a/internal/commands/storage/backup_create.go
+++ b/internal/commands/storage/backup_create.go
@@ -57,7 +57,7 @@ func (s *createBackupCommand) Execute(exec commands.Executor, uuid string) (outp
 	if s.params.Title == "" {
 		return nil, fmt.Errorf("title is required")
 	}
-	msg := fmt.Sprintf("backing up %v", uuid)
+	msg := fmt.Sprintf("Backing up storage %v to %v", uuid, s.params.Title)
 	logline := exec.NewLogEntry(msg)
 	logline.StartedNow()
 

--- a/internal/commands/storage/backup_create.go
+++ b/internal/commands/storage/backup_create.go
@@ -74,5 +74,7 @@ func (s *createBackupCommand) Execute(exec commands.Executor, uuid string) (outp
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
 
-	return output.OnlyMarshaled{Value: res}, nil
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "UUID", Value: res.UUID, Colour: ui.DefaultUUUIDColours},
+	}}, nil
 }

--- a/internal/commands/storage/create.go
+++ b/internal/commands/storage/create.go
@@ -98,7 +98,7 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 		return nil, err
 	}
 
-	msg := "creating storage"
+	msg := fmt.Sprintf("Creating storage %s", s.params.Title)
 	logline := exec.NewLogEntry(msg)
 	logline.StartedNow()
 

--- a/internal/commands/storage/create.go
+++ b/internal/commands/storage/create.go
@@ -112,5 +112,7 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
 
-	return output.OnlyMarshaled{Value: res}, nil
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "UUID", Value: res.UUID, Colour: ui.DefaultUUUIDColours},
+	}}, nil
 }

--- a/internal/commands/storage/delete.go
+++ b/internal/commands/storage/delete.go
@@ -43,7 +43,7 @@ func (s *deleteCommand) MaximumExecutions() int {
 // Execute implements commands.MultipleArgumentCommand
 func (s *deleteCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
 	svc := exec.Storage()
-	msg := fmt.Sprintf("deleting storage %v", uuid)
+	msg := fmt.Sprintf("Deleting storage %v", uuid)
 	logline := exec.NewLogEntry(msg)
 
 	logline.StartedNow()
@@ -58,6 +58,7 @@ func (s *deleteCommand) Execute(exec commands.Executor, uuid string) (output.Out
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
+	logline.MarkDone()
 
 	return output.None{}, nil
 }

--- a/internal/ui/log.go
+++ b/internal/ui/log.go
@@ -133,8 +133,7 @@ func (s *LiveLog) Render() {
 	// Move pending entries that have started to in progress
 	newPending := s.entriesPending[:0]
 	for _, entry := range s.entriesPending {
-		isStarted := !entry.started.IsZero()
-		if !isStarted {
+		if entry.started.IsZero() {
 			newPending = append(newPending, entry)
 			continue
 		}

--- a/internal/ui/log.go
+++ b/internal/ui/log.go
@@ -129,6 +129,20 @@ func (s *LiveLog) Render() {
 		s.eraseLine()                   // erase the end of line
 		s.write(text.CursorUp.Sprint()) // and move up
 	}
+
+	// Move pending entries that have started to in progress
+	newPending := s.entriesPending[:0]
+	for _, entry := range s.entriesPending {
+		isStarted := !entry.started.IsZero()
+		if !isStarted {
+			newPending = append(newPending, entry)
+			continue
+		}
+		s.entriesInProgress = append(s.entriesInProgress, entry)
+	}
+	s.entriesPending = newPending
+
+	// Move in progress entries that have completed to done
 	newInProgress := s.entriesInProgress[:0]
 	// Render any completed
 	for _, entry := range s.entriesInProgress {
@@ -146,18 +160,6 @@ func (s *LiveLog) Render() {
 		}
 	}
 	s.entriesInProgress = newInProgress
-
-	// Add any pending entries that have started
-	newPending := s.entriesPending[:0]
-	for _, entry := range s.entriesPending {
-		isStarted := !entry.started.IsZero()
-		if !isStarted {
-			newPending = append(newPending, entry)
-			continue
-		}
-		s.entriesInProgress = append(s.entriesInProgress, entry)
-	}
-	s.entriesPending = newPending
 
 	if s.config.DisableLiveRendering {
 		return

--- a/internal/ui/log_test.go
+++ b/internal/ui/log_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLogRender ensures that log entries are outputted with single Render call
+func TestLogRender(t *testing.T) {
+	var b bytes.Buffer
+	config := LiveLogDefaultConfig
+	config.EntryMaxWidth = 50
+	livelog := NewLiveLog(&b, config)
+
+	// Simulate typical livelog usage
+	msg := "Testing log.Render"
+	entry := NewLogEntry(msg)
+	livelog.AddEntries(entry)
+	entry.StartedNow()
+	entry.SetMessage(fmt.Sprintf("%s: Done", msg))
+	entry.MarkDone()
+	livelog.Render()
+	livelog.Close()
+
+	assert.Contains(t, b.String(), msg)
+	assert.Contains(t, b.String(), ": Done")
+}


### PR DESCRIPTION
This PR also fixes livelog rendering of quick commands (execution takes less than render tick interval) and syncs livelog formatting of related commands.