### PR TITLE
chore(lib): update UpCloud Go API client library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `storage modify` command now accepts `enable-filesystem-autoresize` flag. When that flag is set upctl will attempt to resize partition and filesystem after storage size has been modified.
 
 ### Changed
-- New go-api version v4.3.0
+- New go-api version v4.5.0
 
 ### Fixed
 - Improved errors relating to argument resolver failures

--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ fmt                  Run gofmt on all source files
 clean                Cleanup everything
 ```
 
+### Debugging
+Environment variables `UPCLOUD_DEBUG_API_BASE_URL` and `UPCLOUD_DEBUG_SKIP_CERTIFICATE_VERIFY` can be used for HTTP client debugging purposes.
+
 ### Requirements
 
 This repository uses [pre-commit](https://pre-commit.com/#install) and [go-critic](https://github.com/go-critic/go-critic)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The detailed documentation can be found [here](docs/upctl.md)
 ## Contributing
 
 Contributions from the community are much appreciated! Please note that all features using our
-API should be implemented with [UpCloud Golang API SDK](https://github.com/UpCloudLtd/upcloud-go-api).
+API should be implemented with [UpCloud Go API SDK](https://github.com/UpCloudLtd/upcloud-go-api).
 If something is missing from there, add an issue or PR in that repository instead before implementing it here.
 
 * Check GitHub issues and pull requests before creating new ones
@@ -168,10 +168,10 @@ If something is missing from there, add an issue or PR in that repository instea
 
 ## Development
 
-* upctl uses [UpCloud Golang API SDK](https://github.com/UpCloudLtd/upcloud-go-api)
+* upctl uses [UpCloud Go API SDK](https://github.com/UpCloudLtd/upcloud-go-api)
 * upctl is built on [Cobra](https://cobra.dev)
 
-You need a Golang version 1.11+ installed on your development machine.
+You need a Go version 1.11+ installed on your development machine.
 Use `make` to build and test the CLI. Makefile help can be found:
 
 ```
@@ -189,7 +189,7 @@ clean                Cleanup everything
 ```
 
 ### Debugging
-Environment variables `UPCLOUD_DEBUG_API_BASE_URL` and `UPCLOUD_DEBUG_SKIP_CERTIFICATE_VERIFY` can be used for HTTP client debugging purposes.
+Environment variables `UPCLOUD_DEBUG_API_BASE_URL` and `UPCLOUD_DEBUG_SKIP_CERTIFICATE_VERIFY` can be used for HTTP client debugging purposes. More information can be found in the client's [README](https://github.com/UpCloudLtd/upcloud-go-api/blob/986ca6da9ca85ff51ecacc588215641e2e384cfa/README.md#debugging) file.
 
 ### Requirements
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/UpCloudLtd/upcloud-cli
 go 1.13
 
 require (
-	github.com/UpCloudLtd/upcloud-go-api/v4 v4.3.0
+	github.com/UpCloudLtd/upcloud-go-api/v4 v4.5.0
 	github.com/adrg/xdg v0.3.2
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/UpCloudLtd/upcloud-go-api/v4 v4.3.0 h1:e5451CIjLBeJf+fAmczTMeaAhIg0TwSB8aQ1PaRSmTY=
-github.com/UpCloudLtd/upcloud-go-api/v4 v4.3.0/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
+github.com/UpCloudLtd/upcloud-go-api/v4 v4.5.0 h1:CyQVxM9kFsSlOrBwi39dfwIVrPBBmLU+jpz7PjARj3I=
+github.com/UpCloudLtd/upcloud-go-api/v4 v4.5.0/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
 github.com/adrg/xdg v0.3.2 h1:GUSGQ5pHdev83AYhDSS1A/CX+0JIsxbiWtow2DSA+RU=
 github.com/adrg/xdg v0.3.2/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
Update `upcloud-go-api` to version v4.5.0.