### PR TITLE
Do not show usage on missing credentials error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Do not display usage if execution fails because of missing credentials
 
 ## [1.2.0] - 2022-04-29
 ### Added

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -107,6 +107,9 @@ func BuildCommand(child Command, parent *cobra.Command, config *config.Config) C
 
 		service, err := config.CreateService()
 		if err != nil {
+			// Error was caused by missing credentials, not incorrect command
+			child.Cobra().SilenceUsage = true
+
 			return fmt.Errorf("cannot create service: %w", err)
 		}
 		return commandRunE(child, service, config, args)


### PR DESCRIPTION
I set the target to `release/v1.2.0` assuming GitHub will automatically update that to `master` once #119 is merged.