### PR TITLE
fix(gorelease): use_buildx is deprecated

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -199,7 +199,7 @@ dockers:
     # different kinds in the future.
     goos: linux
     goarch: amd64
-    use_buildx: true
+    use: buildx
     dockerfile: Dockerfile.goreleaser
 
     image_templates:

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Once the pull request is created, please make changes to your branch based on th
 Current release process:
 
 * Update CHANGELOG.md
+* Test GoReleaser config with `goreleaser check`
 * Tag a commit with the version you want to release e.g. `v1.2.3`
 * Push the tag & commit to GitHub
   * GitHub actions will automatically set the version based on the tag, create a GitHub release, build the project, and upload binaries & SHA sum to the GitHub release


### PR DESCRIPTION
`use_buildx` is deprecated in favor of the more generalist `use`.