### PR TITLE
feat(server): add wait flag to create and stop commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add `zone list` command that lists available zones.
+- Add `--wait` flag to `server create` and `server stop` commands to wait until server is in `started` and `stopped` state, respectively.
 
 ### Fixed
 - Do not display usage if execution fails because of missing credentials

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -369,14 +369,11 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 		return nil, err
 	}
 
-	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
-	logline.MarkDone()
-
 	if s.wait.Value() {
-		logline := exec.NewLogEntry(msg)
-		if err := waitForServerState(res.UUID, upcloud.ServerStateStarted, serverSvc, logline); err != nil {
-			return nil, err
-		}
+		waitForServerState(res.UUID, upcloud.ServerStateStarted, serverSvc, logline, msg)
+	} else {
+		logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
+		logline.MarkDone()
 	}
 
 	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -31,23 +31,21 @@ type serverCommand struct {
 	*commands.BaseCommand
 }
 
-func waitForServerState(uuid, state string, service service.Server, logline *ui.LogEntry) error {
-	msg := fmt.Sprintf("Waiting for server %s to be in %s state", uuid, state)
-	logline.SetMessage(fmt.Sprintf("%s: polling", msg))
-	logline.StartedNow()
+// waitForServerState waits for server to reach given state and updates given logline with wait progress. Finally, logline is updated with given msg and either done state or timeout warning.
+func waitForServerState(uuid, state string, service service.Server, logline *ui.LogEntry, msg string) {
+	logline.SetMessage(fmt.Sprintf("Waiting for server %s to be in %s state: polling", uuid, state))
 
 	if _, err := service.WaitForServerState(&request.WaitForServerStateRequest{
 		UUID:         uuid,
 		DesiredState: state,
 		Timeout:      5 * time.Minute,
 	}); err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
+		logline.SetMessage(ui.LiveLogEntryWarningColours.Sprintf("%s: partially done (%v)", msg, err.Error()))
 		logline.SetDetails(err.Error(), "error: ")
-		return err
+
+		return
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
-
-	return nil
 }

--- a/internal/commands/server/start.go
+++ b/internal/commands/server/start.go
@@ -53,7 +53,7 @@ func (s *startCommand) Execute(exec commands.Executor, uuid string) (output.Outp
 		return nil, err
 	}
 
-	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
+	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()
 
 	return output.OnlyMarshaled{Value: res}, nil

--- a/internal/commands/server/stop.go
+++ b/internal/commands/server/stop.go
@@ -65,14 +65,11 @@ func (s *stopCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 		return nil, err
 	}
 
-	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
-	logline.MarkDone()
-
 	if s.wait.Value() {
-		logline := exec.NewLogEntry(msg)
-		if err := waitForServerState(uuid, upcloud.ServerStateStopped, svc, logline); err != nil {
-			return nil, err
-		}
+		waitForServerState(uuid, upcloud.ServerStateStopped, svc, logline, msg)
+	} else {
+		logline.SetMessage(fmt.Sprintf("%s: request sent", msg))
+		logline.MarkDone()
 	}
 
 	return output.OnlyMarshaled{Value: res}, nil


### PR DESCRIPTION
Script to test this:

```bash
#!/bin/bash -xe
prefix=server-wait-flag-test-

./bin/upctl server create --wait --hostname ${prefix}server --network type=public --zone pl-waw1 --ssh-keys ~/.ssh/id_ed25519.pub

# Server seems to ignore stop, if it is done right after start
sleep 15

./bin/upctl server stop --wait ${prefix}server

./bin/upctl server delete ${prefix}server
```