### PR TITLE
fix(livelog): mark error and warning livelogs finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Do not display usage if execution fails because of missing credentials
+- Mark error and warning livelogs finished when they will not be updated anymore: this stops the timer in the end of the row and stops livelog from refreshing these lines.
 
 ## [1.2.0] - 2022-04-29
 ### Added

--- a/internal/commands/ipaddress/assign.go
+++ b/internal/commands/ipaddress/assign.go
@@ -86,12 +86,12 @@ func (s *assignCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 		Zone:       s.zone,
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
+
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
+
 	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
 		{Title: "IP Address", Value: res.Address, Colour: ui.DefaultAddressColours},
 	}}, nil

--- a/internal/commands/ipaddress/modify.go
+++ b/internal/commands/ipaddress/modify.go
@@ -8,7 +8,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
 )
@@ -62,11 +61,11 @@ func (s *modifyCommand) Execute(exec commands.Executor, arg string) (output.Outp
 		PTRRecord: s.ptrrecord,
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
+
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
+
 	return output.OnlyMarshaled{Value: res}, nil
 }

--- a/internal/commands/ipaddress/remove.go
+++ b/internal/commands/ipaddress/remove.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 )
 
@@ -50,11 +49,11 @@ func (s *removeCommand) Execute(exec commands.Executor, arg string) (output.Outp
 		IPAddress: arg,
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
+
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
+
 	return output.None{}, nil
 }

--- a/internal/commands/network/create.go
+++ b/internal/commands/network/create.go
@@ -107,19 +107,17 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 
 	req, err := s.buildRequest()
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	res, err := svc.CreateNetwork(req)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
+
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()
+
 	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
 		{Title: "UUID", Value: res.UUID, Colour: ui.DefaultUUUIDColours},
 	}}, nil

--- a/internal/commands/network/delete.go
+++ b/internal/commands/network/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 )
 
@@ -44,9 +43,7 @@ func (s *deleteCommand) Execute(exec commands.Executor, arg string) (output.Outp
 		UUID: arg,
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))
 	logline.MarkDone()

--- a/internal/commands/network/modify.go
+++ b/internal/commands/network/modify.go
@@ -12,7 +12,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 )
 
 type modifyCommand struct {
@@ -89,9 +88,7 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 			IPNetworks: networks,
 		})
 		if err != nil {
-			logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-			logline.SetDetails(err.Error(), "error: ")
-			return nil, err
+			return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 		}
 		// store the result in order to return it
 		network = res
@@ -113,8 +110,7 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 			RouterUUID:  routerUUID,
 		})
 		if err != nil {
-			logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-			logline.SetDetails(err.Error(), "error: ")
+			commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err) // nolint:errcheck
 			return nil, fmt.Errorf("cannot attach router '%s': %w", s.attachRouter, err)
 		}
 		// update the stored result (if we have one) manually to avoid refetching later
@@ -127,8 +123,7 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 			NetworkUUID: arg,
 		})
 		if err != nil {
-			logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-			logline.SetDetails(err.Error(), "error: ")
+			commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err) // nolint:errcheck
 			return nil, fmt.Errorf("cannot detach router '%s': %w", s.attachRouter, err)
 		}
 		// update the stored result (if we have one) manually to avoid refetching later

--- a/internal/commands/networkinterface/create.go
+++ b/internal/commands/networkinterface/create.go
@@ -101,9 +101,7 @@ func (s *createCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 		Bootable:          s.bootable.AsUpcloudBoolean(),
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/networkinterface/delete.go
+++ b/internal/commands/networkinterface/delete.go
@@ -8,7 +8,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
 )
@@ -62,9 +61,7 @@ func (s *deleteCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 	})
 
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/networkinterface/modify.go
+++ b/internal/commands/networkinterface/modify.go
@@ -9,7 +9,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
 )
@@ -90,9 +89,7 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 		Bootable:          *bootable,
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/router/create.go
+++ b/internal/commands/router/create.go
@@ -51,9 +51,7 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 
 	res, err := exec.Network().CreateRouter(&request.CreateRouterRequest{Name: s.name})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/router/delete.go
+++ b/internal/commands/router/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 )
 
@@ -46,9 +45,7 @@ func (s *deleteCommand) Execute(exec commands.Executor, arg string) (output.Outp
 
 	err := exec.Network().DeleteRouter(&request.DeleteRouterRequest{UUID: arg})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/router/modify.go
+++ b/internal/commands/router/modify.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
 )
@@ -48,9 +47,7 @@ func (s *modifyCommand) ExecuteSingleArgument(exec commands.Executor, arg string
 	logline.StartedNow()
 	res, err := exec.Network().ModifyRouter(&request.ModifyRouterRequest{UUID: arg, Name: s.name})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -364,9 +364,7 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 
 	res, err := serverSvc.CreateServer(&req)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	if s.wait.Value() {

--- a/internal/commands/server/delete.go
+++ b/internal/commands/server/delete.go
@@ -8,7 +8,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
@@ -62,9 +61,7 @@ func (s *deleteCommand) Execute(exec commands.Executor, uuid string) (output.Out
 		})
 	}
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/server/eject.go
+++ b/internal/commands/server/eject.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 )
@@ -47,9 +46,7 @@ func (s *ejectCommand) Execute(exec commands.Executor, uuid string) (output.Outp
 
 	res, err := svc.EjectCDROM(&req)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))

--- a/internal/commands/server/load.go
+++ b/internal/commands/server/load.go
@@ -8,7 +8,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
@@ -75,9 +74,7 @@ func (s *loadCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 
 	res, err := svc.LoadCDROM(&req)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))

--- a/internal/commands/server/modify.go
+++ b/internal/commands/server/modify.go
@@ -8,7 +8,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
@@ -107,9 +106,7 @@ func (s *modifyCommand) Execute(exec commands.Executor, uuid string) (output.Out
 	req.UUID = uuid
 	res, err := svc.ModifyServer(&req)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/server/restart.go
+++ b/internal/commands/server/restart.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"time"
 
@@ -69,9 +68,7 @@ func (s *restartCommand) Execute(exec commands.Executor, uuid string) (output.Ou
 		TimeoutAction: "ignore",
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: request sent", msg))

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -40,8 +40,9 @@ func waitForServerState(uuid, state string, service service.Server, logline *ui.
 		DesiredState: state,
 		Timeout:      5 * time.Minute,
 	}); err != nil {
-		logline.SetMessage(ui.LiveLogEntryWarningColours.Sprintf("%s: partially done (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
+		logline.SetMessage(fmt.Sprintf("%s: partially done", msg))
+		logline.SetDetails(err.Error(), "Error: ")
+		logline.MarkWarning()
 
 		return
 	}

--- a/internal/commands/server/start.go
+++ b/internal/commands/server/start.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 )
@@ -48,9 +47,7 @@ func (s *startCommand) Execute(exec commands.Executor, uuid string) (output.Outp
 		UUID: uuid,
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/server/stop.go
+++ b/internal/commands/server/stop.go
@@ -8,7 +8,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
@@ -60,9 +59,7 @@ func (s *stopCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 		StopType: s.StopType,
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	if s.wait.Value() {

--- a/internal/commands/serverfirewall/create.go
+++ b/internal/commands/serverfirewall/create.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/m7shapan/cidr"
@@ -155,9 +154,7 @@ func (s *createCommand) Execute(exec commands.Executor, arg string) (output.Outp
 		},
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))
 	logline.MarkDone()

--- a/internal/commands/serverfirewall/delete.go
+++ b/internal/commands/serverfirewall/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
 )
@@ -53,9 +52,7 @@ func (s *deleteCommand) Execute(exec commands.Executor, arg string) (output.Outp
 		Position:   s.rulePosition,
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/serverstorage/attach.go
+++ b/internal/commands/serverstorage/attach.go
@@ -9,7 +9,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
@@ -95,9 +94,7 @@ func (s *attachCommand) ExecuteSingleArgument(exec commands.Executor, uuid strin
 	res, err := storageSvc.AttachStorage(&req)
 
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))

--- a/internal/commands/serverstorage/detach.go
+++ b/internal/commands/serverstorage/detach.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
@@ -73,9 +72,7 @@ func (s *detachCommand) ExecuteSingleArgument(exec commands.Executor, uuid strin
 	res, err := storageSvc.DetachStorage(&req)
 
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))

--- a/internal/commands/storage/backup_create.go
+++ b/internal/commands/storage/backup_create.go
@@ -66,9 +66,7 @@ func (s *createBackupCommand) Execute(exec commands.Executor, uuid string) (outp
 
 	res, err := svc.CreateBackup(&req)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))

--- a/internal/commands/storage/backup_restore.go
+++ b/internal/commands/storage/backup_restore.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 )
@@ -50,9 +49,7 @@ func (s *restoreBackupCommand) Execute(exec commands.Executor, uuid string) (out
 
 	err := svc.RestoreBackup(&req)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))

--- a/internal/commands/storage/clone.go
+++ b/internal/commands/storage/clone.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
@@ -73,9 +72,7 @@ func (s *cloneCommand) Execute(exec commands.Executor, uuid string) (output.Outp
 
 	res, err := svc.CloneStorage(&req)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))

--- a/internal/commands/storage/create.go
+++ b/internal/commands/storage/create.go
@@ -104,9 +104,7 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 
 	res, err := svc.CreateStorage(&s.params.CreateStorageRequest)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))

--- a/internal/commands/storage/delete.go
+++ b/internal/commands/storage/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 )
@@ -52,9 +51,7 @@ func (s *deleteCommand) Execute(exec commands.Executor, uuid string) (output.Out
 		UUID: uuid,
 	})
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/storage/import.go
+++ b/internal/commands/storage/import.go
@@ -195,9 +195,7 @@ func (s *importCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 		switch {
 		case statusUpdate.err != nil:
 			// we received an error, clean up log and return the error
-			logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, statusUpdate.err.Error()))
-			logline.SetDetails(statusUpdate.err.Error(), "error: ")
-			return nil, statusUpdate.err
+			return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), statusUpdate.err)
 		case statusUpdate.complete:
 			// we're complete, clean up log and return the result
 			logline.SetMessage(fmt.Sprintf("%s: done", msg))
@@ -273,8 +271,7 @@ func createStorage(exec commands.Executor, params *createParams) (upcloud.Storag
 	logline.StartedNow()
 	details, err := exec.Storage().CreateStorage(&params.CreateStorageRequest)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed", msg))
-		logline.SetDetails(err.Error(), "error: ")
+		commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err) // nolint:errcheck
 		return upcloud.Storage{}, err
 	}
 	logline.SetMessage(fmt.Sprintf("%s: done", msg))

--- a/internal/commands/storage/templatize.go
+++ b/internal/commands/storage/templatize.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
-	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/spf13/pflag"
@@ -68,9 +67,7 @@ func (s *templatizeCommand) Execute(exec commands.Executor, uuid string) (output
 
 	res, err := svc.TemplatizeStorage(&req)
 	if err != nil {
-		logline.SetMessage(ui.LiveLogEntryErrorColours.Sprintf("%s: failed (%v)", msg, err.Error()))
-		logline.SetDetails(err.Error(), "error: ")
-		return nil, err
+		return commands.HandleError(logline, fmt.Sprintf("%s: failed", msg), err)
 	}
 
 	logline.SetMessage(fmt.Sprintf("%s: success", msg))

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -9,6 +9,8 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
 	"github.com/jedib0t/go-pretty/v6/text"
 
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-cli/internal/validation"
 )
 
@@ -114,4 +116,13 @@ func BoolFromString(b string) (*upcloud.Boolean, error) {
 		return nil, fmt.Errorf("invalid boolean value %s", b)
 	}
 	return &result, nil
+}
+
+// HandleError logs error in livelog by setting message to msg and details to err. Returns (nil, err), where err is the err passed in as input.
+func HandleError(logline *ui.LogEntry, msg string, err error) (output.Output, error) {
+	logline.SetMessage(msg)
+	logline.SetDetails(err.Error(), "Error: ")
+	logline.MarkFailed()
+
+	return nil, err
 }


### PR DESCRIPTION
This stops the timer from the end of the error and warning rows and stops livelog from refreshing lines that will not be updated.

Script to test this:
```bash
#!/bin/bash -xe
prefix=livelog-errors-test-

./bin/upctl server create --wait --hostname ${prefix}server-1 --network type=public --zone pl-waw1 --ssh-keys ~/.ssh/id_ed25519.pub
./bin/upctl server create --wait --hostname ${prefix}server-2 --network type=public --zone pl-waw1 --ssh-keys ~/.ssh/id_ed25519.pub

# Server seems to ignore stop, if it is done right after start
sleep 10

./bin/upctl server stop --wait ${prefix}server-1

# Output of this command is where the fix is visible (and bug was visible)
./bin/upctl server stop --wait ${prefix}server-1 ${prefix}server-2

./bin/upctl server delete ${prefix}server-1 ${prefix}server-2
```

Built on top of #123. Thus the target branch.