### PR TITLE
Add loadbalancer list and show commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `database list`, `database show`,`database plans`, and `database types` commands.
+- Add `loadbalancer list` and `loadbalancer show` commands.
 
 ### Changed
 - Color server state in `server list` output similarly than in `server show` output.

--- a/README.md
+++ b/README.md
@@ -12,17 +12,18 @@ Usage:
 upctl [command]
 
 Available Commands:
-account     Manage account
-completion  Generates shell completion
-database    Manage databases
-help        Help about any command
-ip-address  Manage ip address
-network     Manage network
-router      Manage router
-server      Manage servers
-storage     Manage storages
-version     Display software information
-zone        Display zone information
+account      Manage account
+completion   Generates shell completion
+database     Manage databases
+help         Help about any command
+ip-address   Manage ip address
+loadbalancer Manage load balancers
+network      Manage network
+router       Manage router
+server       Manage servers
+storage      Manage storages
+version      Display software information
+zone         Display zone information
 
 Options:
   -t, --client-timeout duration   CLI timeout when using interactive mode on some commands

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -110,6 +110,7 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	// LoadBalancers
 	loadbalancerCommand := commands.BuildCommand(loadbalancer.BaseLoadBalancerCommand(), rootCmd, conf)
 	commands.BuildCommand(loadbalancer.ListCommand(), loadbalancerCommand.Cobra(), conf)
+	commands.BuildCommand(loadbalancer.ShowCommand(), loadbalancerCommand.Cobra(), conf)
 
 	// Misc
 	commands.BuildCommand(

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/account"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/database"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/ipaddress"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/loadbalancer"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/network"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/networkinterface"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/root"
@@ -105,6 +106,10 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	commands.BuildCommand(database.ShowCommand(), databaseCommand.Cobra(), conf)
 	commands.BuildCommand(database.TypesCommand(), databaseCommand.Cobra(), conf)
 	commands.BuildCommand(database.PlansCommand(), databaseCommand.Cobra(), conf)
+
+	// LoadBalancers
+	loadbalancerCommand := commands.BuildCommand(loadbalancer.BaseLoadBalancerCommand(), rootCmd, conf)
+	commands.BuildCommand(loadbalancer.ListCommand(), loadbalancerCommand.Cobra(), conf)
 
 	// Misc
 	commands.BuildCommand(

--- a/internal/commands/database/database.go
+++ b/internal/commands/database/database.go
@@ -4,7 +4,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 )
 
-// BaseDatabaseCommand creates the base "zone" command
+// BaseDatabaseCommand creates the base "database" command
 func BaseDatabaseCommand() commands.Command {
 	return &databaseCommand{
 		commands.New("database", "Manage databases"),

--- a/internal/commands/loadbalancer/list.go
+++ b/internal/commands/loadbalancer/list.go
@@ -1,0 +1,52 @@
+package loadbalancer
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+)
+
+// ListCommand creates the "loadbalancer list" command
+func ListCommand() commands.Command {
+	return &listCommand{
+		BaseCommand: commands.New("list", "List current load balancers", "upctl loadbalancer list"),
+	}
+}
+
+type listCommand struct {
+	*commands.BaseCommand
+}
+
+// ExecuteWithoutArguments implements commands.NoArgumentCommand
+func (s *listCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
+	svc := exec.All()
+	loadbalancers, err := svc.GetLoadBalancers(&request.GetLoadBalancersRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	rows := []output.TableRow{}
+	for _, lb := range loadbalancers {
+		coloredState := commands.LoadBalancerOperationalStateColour(lb.OperationalState).Sprint(lb.OperationalState)
+
+		rows = append(rows, output.TableRow{
+			lb.UUID,
+			lb.Name,
+			lb.Plan,
+			lb.Zone,
+			coloredState,
+		})
+	}
+
+	return output.Table{
+		Columns: []output.TableColumn{
+			{Key: "uuid", Header: "UUID", Colour: ui.DefaultUUUIDColours},
+			{Key: "name", Header: "Name"},
+			{Key: "plan", Header: "Plan"},
+			{Key: "zone", Header: "Zone"},
+			{Key: "state", Header: "State"},
+		},
+		Rows: rows,
+	}, nil
+}

--- a/internal/commands/loadbalancer/loadbalancer.go
+++ b/internal/commands/loadbalancer/loadbalancer.go
@@ -1,0 +1,16 @@
+package loadbalancer
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+)
+
+// BaseLoadBalancerCommand creates the base "loadbalancer" command
+func BaseLoadBalancerCommand() commands.Command {
+	return &loadbalancerCommand{
+		commands.New("loadbalancer", "Manage load balancers"),
+	}
+}
+
+type loadbalancerCommand struct {
+	*commands.BaseCommand
+}

--- a/internal/commands/loadbalancer/show.go
+++ b/internal/commands/loadbalancer/show.go
@@ -1,6 +1,8 @@
 package loadbalancer
 
 import (
+	"strings"
+
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
@@ -69,6 +71,19 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 		})
 	}
 
+	resolverRows := []output.TableRow{}
+	for _, resolver := range lb.Resolvers {
+		var nameservers []string
+		for _, nameserver := range resolver.Nameservers {
+			nameservers = append(nameservers, ui.DefaultAddressColours.Sprint(nameserver))
+		}
+
+		resolverRows = append(resolverRows, output.TableRow{
+			resolver.Name,
+			strings.Join(nameservers, ", "),
+		})
+	}
+
 	// For JSON and YAML output, passthrough API response
 	return output.MarshaledWithHumanOutput{
 		Value: lb,
@@ -115,6 +130,16 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 						{Key: "rules", Header: "Rules"},
 					},
 					Rows: frontEndRows,
+				},
+			},
+			output.CombinedSection{
+				Title: "Resolvers:",
+				Contents: output.Table{
+					Columns: []output.TableColumn{
+						{Key: "name", Header: "Name"},
+						{Key: "nameservers", Header: "Nameservers"},
+					},
+					Rows: resolverRows,
 				},
 			},
 		},

--- a/internal/commands/loadbalancer/show.go
+++ b/internal/commands/loadbalancer/show.go
@@ -1,0 +1,120 @@
+package loadbalancer
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+// ShowCommand creates the "loadbalancer show" command
+func ShowCommand() commands.Command {
+	return &showCommand{
+		BaseCommand: commands.New(
+			"show",
+			"Show load balancer details",
+			"upctl loadbalancer show 55199a44-4751-4e27-9394-7c7661910be3",
+			"upctl loadbalancer show my-load-balancer",
+		),
+	}
+}
+
+type showCommand struct {
+	*commands.BaseCommand
+	// resolver.CachingLoadBalancer
+	// completion.LoadBalancer
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
+	svc := exec.All()
+	lb, err := svc.GetLoadBalancer(&request.GetLoadBalancerRequest{UUID: uuid})
+	if err != nil {
+		return nil, err
+	}
+
+	var networkName string
+	if network, err := svc.GetNetworkDetails(&request.GetNetworkDetailsRequest{UUID: lb.NetworkUUID}); err != nil {
+		networkName = text.FgHiBlack.Sprint("Unknown")
+	} else {
+		networkName = network.Name
+	}
+
+	backEndRows := []output.TableRow{}
+	for _, backEnd := range lb.Backends {
+		resolver := text.FgHiBlack.Sprint("None")
+		if backEnd.Resolver != "" {
+			resolver = backEnd.Resolver
+		}
+
+		backEndRows = append(backEndRows, output.TableRow{
+			backEnd.Name,
+			resolver,
+			len(backEnd.Members),
+		})
+	}
+
+	frontEndRows := []output.TableRow{}
+	for _, frontEnd := range lb.Frontends {
+		frontEndRows = append(frontEndRows, output.TableRow{
+			frontEnd.Name,
+			frontEnd.Mode,
+			frontEnd.Port,
+			len(frontEnd.TLSConfigs),
+			frontEnd.DefaultBackend,
+			len(frontEnd.Rules),
+		})
+	}
+
+	// For JSON and YAML output, passthrough API response
+	return output.MarshaledWithHumanOutput{
+		Value: lb,
+		Output: output.Combined{
+			output.CombinedSection{
+				Contents: output.Details{
+					Sections: []output.DetailSection{
+						{
+							Title: "Overview:",
+							Rows: []output.DetailRow{
+								{Title: "UUID:", Value: lb.UUID, Colour: ui.DefaultUUUIDColours},
+								{Title: "Name:", Value: lb.Name},
+								{Title: "Plan:", Value: lb.Plan},
+								{Title: "Zone:", Value: lb.Zone},
+								{Title: "DNS name", Value: lb.DNSName},
+								{Title: "Network name", Value: networkName},
+								{Title: "Network UUID", Value: lb.NetworkUUID},
+								{Title: "Operational state:", Value: lb.OperationalState, Colour: commands.LoadBalancerOperationalStateColour(lb.OperationalState)},
+							},
+						},
+					},
+				},
+			},
+			output.CombinedSection{
+				Title: "Backends:",
+				Contents: output.Table{
+					Columns: []output.TableColumn{
+						{Key: "name", Header: "Name"},
+						{Key: "resolver", Header: "Resolver"},
+						{Key: "members", Header: "Members"},
+					},
+					Rows: backEndRows,
+				},
+			},
+			output.CombinedSection{
+				Title: "Frontends:",
+				Contents: output.Table{
+					Columns: []output.TableColumn{
+						{Key: "name", Header: "Name"},
+						{Key: "mode", Header: "Mode"},
+						{Key: "port", Header: "Port"},
+						{Key: "tls_configs", Header: "TLS configs"},
+						{Key: "default_backend", Header: "Default Backend"},
+						{Key: "rules", Header: "Rules"},
+					},
+					Rows: frontEndRows,
+				},
+			},
+		},
+	}, nil
+}

--- a/internal/commands/loadbalancer/show.go
+++ b/internal/commands/loadbalancer/show.go
@@ -2,7 +2,9 @@ package loadbalancer
 
 import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -22,8 +24,8 @@ func ShowCommand() commands.Command {
 
 type showCommand struct {
 	*commands.BaseCommand
-	// resolver.CachingLoadBalancer
-	// completion.LoadBalancer
+	resolver.CachingLoadBalancer
+	completion.LoadBalancer
 }
 
 // Execute implements commands.MultipleArgumentCommand

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -84,6 +84,18 @@ func DatabaseStateColour(state upcloud.ManagedDatabaseState) text.Colors {
 	}
 }
 
+// LoadBalancerOperationalStateColour maps load balancer states to colours
+func LoadBalancerOperationalStateColour(state upcloud.LoadBalancerOperationalState) text.Colors {
+	switch state {
+	case upcloud.LoadBalancerOperationalStateRunning:
+		return text.Colors{text.FgGreen}
+	case upcloud.LoadBalancerOperationalStateCheckup, upcloud.LoadBalancerOperationalStatePending, upcloud.LoadBalancerOperationalStateSetupAgent, upcloud.LoadBalancerOperationalStateSetupDNS, upcloud.LoadBalancerOperationalStateSetupLB, upcloud.LoadBalancerOperationalStateSetupNetwork, upcloud.LoadBalancerOperationalStateSetupServer:
+		return text.Colors{text.FgYellow}
+	default:
+		return text.Colors{text.FgHiBlack}
+	}
+}
+
 // ServerStateColour is a helper mapping server states to colours
 func ServerStateColour(state string) text.Colors {
 	switch state {

--- a/internal/completion/loadbalancer.go
+++ b/internal/completion/loadbalancer.go
@@ -1,0 +1,28 @@
+package completion
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+	"github.com/spf13/cobra"
+)
+
+// LoadBalancer implements argument completion for load balancers, by uuid or name.
+type LoadBalancer struct {
+}
+
+// make sure LoadBalancer implements the interface
+var _ Provider = LoadBalancer{}
+
+// CompleteArgument implements completion.Provider
+func (s LoadBalancer) CompleteArgument(svc service.AllServices, toComplete string) ([]string, cobra.ShellCompDirective) {
+	loadbalancers, err := svc.GetLoadBalancers(&request.GetLoadBalancersRequest{})
+	if err != nil {
+		return None(toComplete)
+	}
+	var vals []string
+	for _, lb := range loadbalancers {
+		vals = append(vals, lb.UUID, lb.Name)
+	}
+
+	return MatchStringPrefix(vals, toComplete, true), cobra.ShellCompDirectiveNoFileComp
+}

--- a/internal/completion/loadbalancer_test.go
+++ b/internal/completion/loadbalancer_test.go
@@ -1,0 +1,50 @@
+package completion_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var mockLoadBalancers = []upcloud.LoadBalancer{
+	{Name: "asd-1", UUID: "abcdef"},
+	{Name: "asd-2", UUID: "abcghi"},
+	{Name: "qwe-1", UUID: "jklmno"},
+}
+
+func TestLoadBalancer_CompleteArgument(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		complete          string
+		expectedMatches   []string
+		expectedDirective cobra.ShellCompDirective
+	}{
+		{name: "Name/UUID - no match", complete: "pqr", expectedMatches: []string(nil), expectedDirective: cobra.ShellCompDirectiveNoFileComp},
+		{name: "UUID - single match", complete: "jkl", expectedMatches: []string{"jklmno"}, expectedDirective: cobra.ShellCompDirectiveNoFileComp},
+		{name: "UUID - multiple matches", complete: "abc", expectedMatches: []string{"abcdef", "abcghi"}, expectedDirective: cobra.ShellCompDirectiveNoFileComp},
+		{name: "Name - one match", complete: "qwe", expectedMatches: []string{"qwe-1"}, expectedDirective: cobra.ShellCompDirectiveNoFileComp},
+		{name: "Name - multiple matches", complete: "asd", expectedMatches: []string{"asd-1", "asd-2"}, expectedDirective: cobra.ShellCompDirectiveNoFileComp},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mService := new(smock.Service)
+			mService.On("GetLoadBalancers", mock.Anything).Return(mockLoadBalancers, nil)
+			completions, directive := completion.LoadBalancer{}.CompleteArgument(mService, test.complete)
+			assert.Equal(t, test.expectedMatches, completions)
+			assert.Equal(t, test.expectedDirective, directive)
+		})
+	}
+}
+
+func TestLoadBalancer_CompleteArgumentServiceFail(t *testing.T) {
+	mService := new(smock.Service)
+	mService.On("GetLoadBalancers", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
+	completions, directive := completion.LoadBalancer{}.CompleteArgument(mService, "asd")
+	assert.Nil(t, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+}

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -647,7 +647,11 @@ func (m *Service) WaitForManagedDatabaseState(r *request.WaitForManagedDatabaseS
 }
 
 func (m *Service) GetLoadBalancers(r *request.GetLoadBalancersRequest) ([]upcloud.LoadBalancer, error) {
-	return nil, nil
+	args := m.Called(r)
+	if args[0] == nil {
+		return nil, args.Error(1)
+	}
+	return args[0].([]upcloud.LoadBalancer), args.Error(1)
 }
 
 func (m *Service) GetLoadBalancer(r *request.GetLoadBalancerRequest) (*upcloud.LoadBalancer, error) {

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -645,3 +645,171 @@ func (m *Service) ShutdownManagedDatabase(r *request.ShutdownManagedDatabaseRequ
 func (m *Service) WaitForManagedDatabaseState(r *request.WaitForManagedDatabaseStateRequest) (*upcloud.ManagedDatabase, error) {
 	return nil, nil
 }
+
+func (m *Service) GetLoadBalancers(r *request.GetLoadBalancersRequest) ([]upcloud.LoadBalancer, error) {
+	return nil, nil
+}
+
+func (m *Service) GetLoadBalancer(r *request.GetLoadBalancerRequest) (*upcloud.LoadBalancer, error) {
+	return nil, nil
+}
+
+func (m *Service) CreateLoadBalancer(r *request.CreateLoadBalancerRequest) (*upcloud.LoadBalancer, error) {
+	return nil, nil
+}
+
+func (m *Service) ModifyLoadBalancer(r *request.ModifyLoadBalancerRequest) (*upcloud.LoadBalancer, error) {
+	return nil, nil
+}
+
+func (m *Service) DeleteLoadBalancer(r *request.DeleteLoadBalancerRequest) error {
+	return nil
+}
+
+func (m *Service) GetLoadBalancerBackends(r *request.GetLoadBalancerBackendsRequest) ([]upcloud.LoadBalancerBackend, error) {
+	return nil, nil
+}
+
+func (m *Service) GetLoadBalancerBackend(r *request.GetLoadBalancerBackendRequest) (*upcloud.LoadBalancerBackend, error) {
+	return nil, nil
+}
+
+func (m *Service) CreateLoadBalancerBackend(r *request.CreateLoadBalancerBackendRequest) (*upcloud.LoadBalancerBackend, error) {
+	return nil, nil
+}
+
+func (m *Service) ModifyLoadBalancerBackend(r *request.ModifyLoadBalancerBackendRequest) (*upcloud.LoadBalancerBackend, error) {
+	return nil, nil
+}
+
+func (m *Service) DeleteLoadBalancerBackend(r *request.DeleteLoadBalancerBackendRequest) error {
+	return nil
+}
+
+func (m *Service) GetLoadBalancerBackendMembers(r *request.GetLoadBalancerBackendMembersRequest) ([]upcloud.LoadBalancerBackendMember, error) {
+	return nil, nil
+}
+
+func (m *Service) GetLoadBalancerBackendMember(r *request.GetLoadBalancerBackendMemberRequest) (*upcloud.LoadBalancerBackendMember, error) {
+	return nil, nil
+}
+
+func (m *Service) CreateLoadBalancerBackendMember(r *request.CreateLoadBalancerBackendMemberRequest) (*upcloud.LoadBalancerBackendMember, error) {
+	return nil, nil
+}
+
+func (m *Service) ModifyLoadBalancerBackendMember(r *request.ModifyLoadBalancerBackendMemberRequest) (*upcloud.LoadBalancerBackendMember, error) {
+	return nil, nil
+}
+
+func (m *Service) DeleteLoadBalancerBackendMember(r *request.DeleteLoadBalancerBackendMemberRequest) error {
+	return nil
+}
+
+func (m *Service) GetLoadBalancerResolvers(r *request.GetLoadBalancerResolversRequest) ([]upcloud.LoadBalancerResolver, error) {
+	return nil, nil
+}
+
+func (m *Service) CreateLoadBalancerResolver(r *request.CreateLoadBalancerResolverRequest) (*upcloud.LoadBalancerResolver, error) {
+	return nil, nil
+}
+
+func (m *Service) GetLoadBalancerResolver(r *request.GetLoadBalancerResolverRequest) (*upcloud.LoadBalancerResolver, error) {
+	return nil, nil
+}
+
+func (m *Service) ModifyLoadBalancerResolver(r *request.ModifyLoadBalancerResolverRequest) (*upcloud.LoadBalancerResolver, error) {
+	return nil, nil
+}
+
+func (m *Service) DeleteLoadBalancerResolver(r *request.DeleteLoadBalancerResolverRequest) error {
+	return nil
+}
+
+func (m *Service) GetLoadBalancerPlans(r *request.GetLoadBalancerPlansRequest) ([]upcloud.LoadBalancerPlan, error) {
+	return nil, nil
+}
+
+func (m *Service) GetLoadBalancerFrontends(r *request.GetLoadBalancerFrontendsRequest) ([]upcloud.LoadBalancerFrontend, error) {
+	return nil, nil
+}
+
+func (m *Service) GetLoadBalancerFrontend(r *request.GetLoadBalancerFrontendRequest) (*upcloud.LoadBalancerFrontend, error) {
+	return nil, nil
+}
+
+func (m *Service) CreateLoadBalancerFrontend(r *request.CreateLoadBalancerFrontendRequest) (*upcloud.LoadBalancerFrontend, error) {
+	return nil, nil
+}
+
+func (m *Service) ModifyLoadBalancerFrontend(r *request.ModifyLoadBalancerFrontendRequest) (*upcloud.LoadBalancerFrontend, error) {
+	return nil, nil
+}
+
+func (m *Service) DeleteLoadBalancerFrontend(r *request.DeleteLoadBalancerFrontendRequest) error {
+	return nil
+}
+
+func (m *Service) GetLoadBalancerFrontendRules(r *request.GetLoadBalancerFrontendRulesRequest) ([]upcloud.LoadBalancerFrontendRule, error) {
+	return nil, nil
+}
+
+func (m *Service) GetLoadBalancerFrontendRule(r *request.GetLoadBalancerFrontendRuleRequest) (*upcloud.LoadBalancerFrontendRule, error) {
+	return nil, nil
+}
+
+func (m *Service) CreateLoadBalancerFrontendRule(r *request.CreateLoadBalancerFrontendRuleRequest) (*upcloud.LoadBalancerFrontendRule, error) {
+	return nil, nil
+}
+
+func (m *Service) ModifyLoadBalancerFrontendRule(r *request.ModifyLoadBalancerFrontendRuleRequest) (*upcloud.LoadBalancerFrontendRule, error) {
+	return nil, nil
+}
+
+func (m *Service) ReplaceLoadBalancerFrontendRule(r *request.ReplaceLoadBalancerFrontendRuleRequest) (*upcloud.LoadBalancerFrontendRule, error) {
+	return nil, nil
+}
+
+func (m *Service) DeleteLoadBalancerFrontendRule(r *request.DeleteLoadBalancerFrontendRuleRequest) error {
+	return nil
+}
+
+func (m *Service) GetLoadBalancerFrontendTLSConfigs(r *request.GetLoadBalancerFrontendTLSConfigsRequest) ([]upcloud.LoadBalancerFrontendTLSConfig, error) {
+	return nil, nil
+}
+
+func (m *Service) GetLoadBalancerFrontendTLSConfig(r *request.GetLoadBalancerFrontendTLSConfigRequest) (*upcloud.LoadBalancerFrontendTLSConfig, error) {
+	return nil, nil
+}
+
+func (m *Service) CreateLoadBalancerFrontendTLSConfig(r *request.CreateLoadBalancerFrontendTLSConfigRequest) (*upcloud.LoadBalancerFrontendTLSConfig, error) {
+	return nil, nil
+}
+
+func (m *Service) ModifyLoadBalancerFrontendTLSConfig(r *request.ModifyLoadBalancerFrontendTLSConfigRequest) (*upcloud.LoadBalancerFrontendTLSConfig, error) {
+	return nil, nil
+}
+
+func (m *Service) DeleteLoadBalancerFrontendTLSConfig(r *request.DeleteLoadBalancerFrontendTLSConfigRequest) error {
+	return nil
+}
+
+func (m *Service) GetLoadBalancerCertificateBundles(r *request.GetLoadBalancerCertificateBundlesRequest) ([]upcloud.LoadBalancerCertificateBundle, error) {
+	return nil, nil
+}
+
+func (m *Service) GetLoadBalancerCertificateBundle(r *request.GetLoadBalancerCertificateBundleRequest) (*upcloud.LoadBalancerCertificateBundle, error) {
+	return nil, nil
+}
+
+func (m *Service) CreateLoadBalancerCertificateBundle(r *request.CreateLoadBalancerCertificateBundleRequest) (*upcloud.LoadBalancerCertificateBundle, error) {
+	return nil, nil
+}
+
+func (m *Service) ModifyLoadBalancerCertificateBundle(r *request.ModifyLoadBalancerCertificateBundleRequest) (*upcloud.LoadBalancerCertificateBundle, error) {
+	return nil, nil
+}
+
+func (m *Service) DeleteLoadBalancerCertificateBundle(r *request.DeleteLoadBalancerCertificateBundleRequest) error {
+	return nil
+}

--- a/internal/resolver/loadbalancer.go
+++ b/internal/resolver/loadbalancer.go
@@ -1,0 +1,40 @@
+package resolver
+
+import (
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+)
+
+// CachingLoadBalancer implements resolver for servers, caching the results
+type CachingLoadBalancer struct{}
+
+// make sure we implement the ResolutionProvider interface
+var _ ResolutionProvider = CachingLoadBalancer{}
+
+// Get implements ResolutionProvider.Get
+func (s CachingLoadBalancer) Get(svc internal.AllServices) (Resolver, error) {
+	loadbalancers, err := svc.GetLoadBalancers(&request.GetLoadBalancersRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return func(arg string) (uuid string, err error) {
+		rv := ""
+		for _, lb := range loadbalancers {
+			if lb.Name == arg || lb.UUID == arg {
+				if rv != "" {
+					return "", AmbiguousResolutionError(arg)
+				}
+				rv = lb.UUID
+			}
+		}
+		if rv != "" {
+			return rv, nil
+		}
+		return "", NotFoundError(arg)
+	}, nil
+}
+
+// PositionalArgumentHelp implements resolver.ResolutionProvider
+func (s CachingLoadBalancer) PositionalArgumentHelp() string {
+	return "<UUID/Name...>" //nolint:goconst
+}

--- a/internal/resolver/loadbalancer_test.go
+++ b/internal/resolver/loadbalancer_test.go
@@ -1,0 +1,90 @@
+package resolver_test
+
+import (
+	"errors"
+	"testing"
+
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var mockLoadBalancers = []upcloud.LoadBalancer{
+	{Name: "asd", UUID: "abcdef"},
+	{Name: "asd", UUID: "abcghi"},
+	{Name: "qwe", UUID: "jklmno"},
+}
+
+func TestLoadBalancerResolution(t *testing.T) {
+	t.Run("UUID", func(t *testing.T) {
+		mService := &smock.Service{}
+		mService.On("GetLoadBalancers", mock.Anything).Return(mockLoadBalancers, nil)
+		res := resolver.CachingLoadBalancer{}
+		argResolver, err := res.Get(mService)
+		assert.NoError(t, err)
+		for _, db := range mockLoadBalancers {
+			resolved, err := argResolver(db.UUID)
+			assert.NoError(t, err)
+			assert.Equal(t, db.UUID, resolved)
+		}
+
+		// Make sure caching works, eg. we didn't call GetLoadBalancers more than once
+		mService.AssertNumberOfCalls(t, "GetLoadBalancers", 1)
+	})
+
+	t.Run("Name", func(t *testing.T) {
+		mService := &smock.Service{}
+		mService.On("GetLoadBalancers", mock.Anything).Return(mockLoadBalancers, nil)
+		res := resolver.CachingLoadBalancer{}
+		argResolver, err := res.Get(mService)
+		assert.NoError(t, err)
+
+		db := mockLoadBalancers[2]
+		resolved, err := argResolver(db.Name)
+		assert.NoError(t, err)
+		assert.Equal(t, db.UUID, resolved)
+		// Make sure caching works, eg. we didn't call GetLoadBalancers more than once
+		mService.AssertNumberOfCalls(t, "GetLoadBalancers", 1)
+	})
+
+	t.Run("Failures", func(t *testing.T) {
+		mService := &smock.Service{}
+		mService.On("GetLoadBalancers", mock.Anything).Return(mockLoadBalancers, nil)
+
+		res := resolver.CachingLoadBalancer{}
+		argResolver, err := res.Get(mService)
+		assert.NoError(t, err)
+		var resolved string
+
+		// Ambigous Name
+		resolved, err = argResolver("asd")
+		if !assert.Error(t, err) {
+			t.FailNow()
+		}
+		assert.ErrorIs(t, err, resolver.AmbiguousResolutionError("asd"))
+		assert.Equal(t, "", resolved)
+
+		// Not found
+		resolved, err = argResolver("not-found")
+		if !assert.Error(t, err) {
+			t.FailNow()
+		}
+		assert.ErrorIs(t, err, resolver.NotFoundError("not-found"))
+		assert.Equal(t, "", resolved)
+
+		// Make sure caching works, eg. we didn't call GetLoadBalancers more than once
+		mService.AssertNumberOfCalls(t, "GetLoadBalancers", 1)
+	})
+}
+
+func TestFailingLoadBalancerResolution(t *testing.T) {
+	mService := &smock.Service{}
+	mService.On("GetLoadBalancers", mock.Anything).Return(nil, errors.New("MOCKERROR"))
+	res := resolver.CachingLoadBalancer{}
+	argResolver, err := res.Get(mService)
+	assert.EqualError(t, err, "MOCKERROR")
+	assert.Nil(t, argResolver)
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -15,6 +15,7 @@ type AllServices interface {
 	service.Account
 	service.Zones
 	service.ManagedDatabaseServiceManager
+	service.LoadBalancer
 }
 
 // Wrapper is a temporary reimplementation fo upcloud-go-api which prevents


### PR DESCRIPTION
Example output:

```txt
$ upctl loadbalancer list

 UUID                                   Name                         Plan          Zone      State   
────────────────────────────────────── ──────────────────────────── ───────────── ───────── ─────────
 0a386b02-6364-4f42-a847-5761cb1f9509   lb-module-basic-example-lb   development   pl-waw1   running 

$ upctl loadbalancer show lb-module-basic-example-lb
  
  Overview:
    UUID:              0a386b02-6364-4f42-a847-5761cb1f9509              
    Name:              lb-module-basic-example-lb                        
    Plan:              development                                       
    Zone:              pl-waw1                                           
    DNS name           lb-0a386b0263644f42a8475761cb1f9509.upcloudlb.com 
    Network name       lb-module-basic-example-net                       
    Network UUID       03c6f6a7-7304-41ed-a29b-d36f471cfd44              
    Operational state: running                                           

  Backends:

     Name   Resolver   Members 
    ────── ────────── ─────────
     main   None             3 
    
  Frontends:

     Name   Mode   Port   TLS configs   Default Backend   Rules 
    ────── ────── ────── ───────────── ───────────────── ───────
     main   http     80             0   main                  0 
    
  Resolvers:

     Name            Nameservers              
    ─────────────── ──────────────────────────
     my-resolver-1   10.0.0.6:53, 10.0.0.5:53 
    
```