### PR TITLE
Add db and lb aliases to database and loadbalancer, respectively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `database list`, `database show`,`database plans`, and `database types` commands.
 - Add `loadbalancer list` and `loadbalancer show` commands.
+- Add `db` and `lb` aliases to `database` and `loadbalancer`, respectively.
 
 ### Changed
 - Color server state in `server list` output similarly than in `server show` output.

--- a/internal/commands/database/database.go
+++ b/internal/commands/database/database.go
@@ -14,3 +14,8 @@ func BaseDatabaseCommand() commands.Command {
 type databaseCommand struct {
 	*commands.BaseCommand
 }
+
+// InitCommand implements Command.InitCommand
+func (db *databaseCommand) InitCommand() {
+	db.Cobra().Aliases = []string{"db"}
+}

--- a/internal/commands/loadbalancer/loadbalancer.go
+++ b/internal/commands/loadbalancer/loadbalancer.go
@@ -14,3 +14,8 @@ func BaseLoadBalancerCommand() commands.Command {
 type loadbalancerCommand struct {
 	*commands.BaseCommand
 }
+
+// InitCommand implements Command.InitCommand
+func (lb *loadbalancerCommand) InitCommand() {
+	lb.Cobra().Aliases = []string{"lb"}
+}


### PR DESCRIPTION
Example usage:

```txt
$ upctl loadbalancer list

 UUID                                   Name                         Plan          Zone      State   
────────────────────────────────────── ──────────────────────────── ───────────── ───────── ─────────
 0a386b02-6364-4f42-a847-5761cb1f9509   lb-module-basic-example-lb   development   pl-waw1   running 

$ upctl lb list

 UUID                                   Name                         Plan          Zone      State   
────────────────────────────────────── ──────────────────────────── ───────────── ───────── ─────────
 0a386b02-6364-4f42-a847-5761cb1f9509   lb-module-basic-example-lb   development   pl-waw1   running 

```
