### PR TITLE
Add --show-ip-addresses flag to server list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `--show-ip-addresses` flag to `server list` command to optionally include IP addresses in command output. 
 
 ## [1.4.0] - 2022-06-15
 ### Added

--- a/internal/commands/server/list.go
+++ b/internal/commands/server/list.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -160,6 +161,24 @@ func getServerIPAddresses(uuid string, svc service.AllServices) ([]listIPAddress
 			})
 		}
 	}
+
+	sort.Slice(ipaddresses, func(i, j int) bool {
+		accessMap := map[string]int{
+			"public":  3,
+			"private": 2,
+			"utility": 1,
+		}
+		floatingMap := map[bool]int{
+			true:  1,
+			false: 0,
+		}
+
+		if accessMap[ipaddresses[i].Access] != accessMap[ipaddresses[j].Access] {
+			return accessMap[ipaddresses[i].Access] > accessMap[ipaddresses[j].Access]
+		}
+
+		return floatingMap[ipaddresses[i].Floating] > floatingMap[ipaddresses[j].Floating]
+	})
 
 	return ipaddresses, nil
 }

--- a/internal/commands/server/list.go
+++ b/internal/commands/server/list.go
@@ -2,10 +2,16 @@ package server
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/pflag"
 )
 
 // ListCommand creates the "server list" command
@@ -15,13 +21,27 @@ func ListCommand() commands.Command {
 	}
 }
 
+type listIPAddress struct {
+	Access   string `json:"access"`
+	Address  string `json:"address"`
+	Floating bool   `json:"floating"`
+}
+
 type listCommand struct {
 	*commands.BaseCommand
+	showIPAddresses config.OptionalBoolean
+}
+
+// InitCommand implements Command.InitCommand
+func (ls *listCommand) InitCommand() {
+	flags := &pflag.FlagSet{}
+	config.AddToggleFlag(flags, &ls.showIPAddresses, "show-ip-addresses", false, "Show IP addresses of the servers in the output.")
+	ls.AddFlags(flags)
 }
 
 // ExecuteWithoutArguments implements commands.NoArgumentCommand
-func (s *listCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
-	svc := exec.Server()
+func (ls *listCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
+	svc := exec.All()
 	servers, err := svc.GetServers()
 	if err != nil {
 		return nil, err
@@ -46,14 +66,91 @@ func (s *listCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Ou
 		})
 	}
 
+	columns := []output.TableColumn{
+		{Key: "uuid", Header: "UUID", Colour: ui.DefaultUUUIDColours},
+		{Key: "hostname", Header: "Hostname"},
+		{Key: "plan", Header: "Plan"},
+		{Key: "zone", Header: "Zone"},
+		{Key: "state", Header: "State"},
+	}
+
+	if ls.showIPAddresses.Value() {
+		ipaddressMap, err := getIPAddressesByServerUUID(svc)
+		if err != nil {
+			return nil, err
+		}
+
+		for i, row := range rows {
+			uuid := row[0].(string)
+
+			var listIpaddresses []listIPAddress
+			if apiIpaddresses, ok := ipaddressMap[uuid]; ok {
+				for _, ipa := range apiIpaddresses {
+					listIpaddresses = append(listIpaddresses, listIPAddress{
+						Access:   ipa.Access,
+						Address:  ipa.Address,
+						Floating: ipa.Floating.Bool(),
+					})
+				}
+			}
+			row = append(row[:3], row[2:]...)
+			row[2] = listIpaddresses
+			rows[i] = row
+		}
+		columns = append(columns[:3], columns[2:]...)
+		columns[2] = output.TableColumn{
+			Key:    "ip_addresses",
+			Header: "IP addresses",
+			Format: formatListIPAddresses,
+		}
+	}
+
 	return output.Table{
-		Columns: []output.TableColumn{
-			{Key: "uuid", Header: "UUID", Colour: ui.DefaultUUUIDColours},
-			{Key: "hostname", Header: "Hostname"},
-			{Key: "plan", Header: "Plan"},
-			{Key: "zone", Header: "Zone"},
-			{Key: "state", Header: "State"},
-		},
-		Rows: rows,
+		Columns: columns,
+		Rows:    rows,
 	}, nil
+}
+
+// getIPAddressesByServerUUID returns IP addresses grouped by server UUID. This function will be removed when server end-point response includes IP addresses.
+func getIPAddressesByServerUUID(svc service.AllServices) (map[string][]upcloud.IPAddress, error) {
+	ipaddresses, err := svc.GetIPAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	ipaddressMap := make(map[string][]upcloud.IPAddress)
+	for _, ipaddress := range ipaddresses.IPAddresses {
+		current, ok := ipaddressMap[ipaddress.ServerUUID]
+		if ok {
+			ipaddressMap[ipaddress.ServerUUID] = append(current, ipaddress)
+		} else {
+			ipaddressMap[ipaddress.ServerUUID] = []upcloud.IPAddress{ipaddress}
+		}
+	}
+
+	return ipaddressMap, nil
+}
+
+func formatListIPAddresses(val interface{}) (text.Colors, string, error) {
+	ipaddresses, ok := val.([]listIPAddress)
+	if !ok {
+		return nil, "", fmt.Errorf("cannot parse IP addresses from %T, expected []listIPAddress", val)
+	}
+
+	var rows []string
+	for _, ipa := range ipaddresses {
+		var floating string
+		if ipa.Floating {
+			floating = " (f)"
+		}
+
+		rows = append(rows, fmt.Sprintf(
+			"%s: %s%s",
+			ipa.Access,
+			ui.DefaultAddressColours.Sprint(ipa.Address),
+			floating,
+		))
+	}
+
+	return nil, strings.Join(rows, ",\n"), nil
 }

--- a/internal/commands/server/list_test.go
+++ b/internal/commands/server/list_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	internal "github.com/UpCloudLtd/upcloud-cli/internal/service"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+	"github.com/gemalto/flume"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListServers(t *testing.T) {
+	text.DisableColors()
+
+	uuid := "server-list-test-server-uuid"
+	servers := upcloud.Servers{
+		Servers: []upcloud.Server{
+			{
+				Hostname: "server-list-test-server",
+				UUID:     uuid,
+				Plan:     "1xCPU-1GB",
+				Zone:     "pl-waw1",
+				State:    "started",
+			},
+		},
+	}
+	serverNetworks := upcloud.Networking{
+		Interfaces: upcloud.ServerInterfaceSlice{
+			{
+				IPAddresses: upcloud.IPAddressSlice{
+					{
+						Access:   "utility",
+						Address:  "10.0.100.1",
+						Floating: upcloud.False,
+					},
+				},
+				Type: "utility",
+			},
+			{
+				IPAddresses: upcloud.IPAddressSlice{
+					{
+						Access:   "private",
+						Address:  "10.0.99.2",
+						Floating: upcloud.False,
+					},
+				},
+				Type: "private",
+			},
+			{
+				IPAddresses: upcloud.IPAddressSlice{
+					{
+						Access:   "public",
+						Address:  "10.0.98.3",
+						Floating: upcloud.False,
+					},
+					{
+						Access:   "public",
+						Address:  "10.0.97.4",
+						Floating: upcloud.True,
+					},
+				},
+				Type: "public",
+			},
+		},
+	}
+
+	ipaddressesTitle := "IP addresses"
+
+	for _, test := range []struct {
+		name              string
+		args              []string
+		outputContains    []string
+		outputNotContains []string
+	}{
+		{
+			name: "No args",
+			args: []string{},
+			outputNotContains: []string{
+				ipaddressesTitle,
+				"10.0.98.3",
+			},
+		},
+		{
+			name: "Show all IP Addresses",
+			args: []string{"--show-ip-addresses"},
+			outputContains: []string{
+				ipaddressesTitle,
+				"public: 10.0.97.4 (f)",
+				"public: 10.0.98.3",
+				"private: 10.0.99.2",
+				"utility: 10.0.100.1",
+			},
+		},
+		{
+			name: "Show public Addresses",
+			args: []string{"--show-ip-addresses=public"},
+			outputContains: []string{
+				ipaddressesTitle,
+				"public: 10.0.97.4 (f)",
+				"public: 10.0.98.3",
+			},
+			outputNotContains: []string{
+				"private: 10.0.99.2",
+				"utility: 10.0.100.1",
+			},
+		},
+		{
+			name: "Show private IP Addresses",
+			args: []string{"--show-ip-addresses=private"},
+			outputContains: []string{
+				ipaddressesTitle,
+				"private: 10.0.99.2",
+			},
+			outputNotContains: []string{
+				"public: 10.0.97.4 (f)",
+				"public: 10.0.98.3",
+				"utility: 10.0.100.1",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			conf := config.New()
+			conf.Viper().Set(config.KeyOutput, config.ValueOutputHuman)
+
+			testCmd := ListCommand()
+			mService := new(smock.Service)
+			conf.Service = internal.Wrapper{Service: mService}
+
+			mService.On("GetServers").Return(&servers, nil)
+			mService.On("GetServerNetworks", &request.GetServerNetworksRequest{ServerUUID: uuid}).Return(&serverNetworks, nil)
+
+			c := commands.BuildCommand(testCmd, nil, conf)
+			err := c.Cobra().Flags().Parse(test.args)
+			assert.NoError(t, err)
+
+			res, err := c.(commands.NoArgumentCommand).ExecuteWithoutArguments(commands.NewExecutor(conf, mService, flume.New("test")))
+			assert.NoError(t, err)
+
+			buf := bytes.NewBuffer(nil)
+			err = output.Render(buf, conf, res)
+			assert.NoError(t, err)
+			str := buf.String()
+
+			for _, contains := range test.outputContains {
+				assert.Contains(t, str, contains)
+			}
+
+			for _, notContains := range test.outputNotContains {
+				assert.NotContains(t, str, notContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements #107 

Example output:

```txt
$ upctl server list --show-ip-addresses

 UUID                                   Hostname                           IP addresses                Plan        Zone      State   
────────────────────────────────────── ────────────────────────────────── ─────────────────────────── ─────────── ───────── ─────────
 7e4c9a57-8cd3-40dd-85db-58fd539d213f   lb-module-basic-example-server-1   public: 10.100.10.3,        1xCPU-1GB   pl-waw1   started 
                                                                           utility: 10.11.2.16                                       
 01eb0dba-49aa-484e-9fde-e9fd7cadcff9   lb-module-basic-example-server-0   public: 10.100.10.4 (f),    1xCPU-1GB   pl-waw1   started 
                                                                           utility: 10.11.0.199,                                     
                                                                           public: 10.100.10.5                                    
 1e19a2f5-6161-4912-828c-ec77fc0089b5   lb-module-basic-example-server-2   utility: 10.11.1.125,       1xCPU-1GB   pl-waw1   started 
                                                                           public: 10.100.10.6                                     
```

### TODO:

- [x] Include private IPs in the list
- [x] Sort addresses by `public` > `private` > `utility`, floating > non-floating
- [x] Check if arg could be used to display IPs of only given access type, e.g. `--show-ip-addresses=public`
- [x] Testing