### PR TITLE
Move storage backup commands into a sub-directory

### DIFF
--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -15,6 +15,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/server/networkinterface"
 	serverstorage "github.com/UpCloudLtd/upcloud-cli/internal/commands/server/storage"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/storage"
+	storagebackup "github.com/UpCloudLtd/upcloud-cli/internal/commands/storage/backup"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/zone"
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 
@@ -65,9 +66,9 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	commands.BuildCommand(storage.ImportCommand(), storageCommand.Cobra(), conf)
 	commands.BuildCommand(storage.ShowCommand(), storageCommand.Cobra(), conf)
 
-	backupCommand := commands.BuildCommand(storage.BackupCommand(), storageCommand.Cobra(), conf)
-	commands.BuildCommand(storage.CreateBackupCommand(), backupCommand.Cobra(), conf)
-	commands.BuildCommand(storage.RestoreBackupCommand(), backupCommand.Cobra(), conf)
+	backupCommand := commands.BuildCommand(storagebackup.BackupCommand(), storageCommand.Cobra(), conf)
+	commands.BuildCommand(storagebackup.CreateBackupCommand(), backupCommand.Cobra(), conf)
+	commands.BuildCommand(storagebackup.RestoreBackupCommand(), backupCommand.Cobra(), conf)
 
 	// IP Addresses
 	ipAddressCommand := commands.BuildCommand(ipaddress.BaseIPAddressCommand(), rootCmd, conf)

--- a/internal/commands/storage/backup/backup.go
+++ b/internal/commands/storage/backup/backup.go
@@ -1,10 +1,14 @@
-package storage
+package storagebackup
 
 import "github.com/UpCloudLtd/upcloud-cli/internal/commands"
 
 // BackupCommand creates the "storage backup" command
 func BackupCommand() commands.Command {
-	return &storageCommand{
+	return &backupCommand{
 		commands.New("backup", "Manage backups"),
 	}
+}
+
+type backupCommand struct {
+	*commands.BaseCommand
 }

--- a/internal/commands/storage/backup/backup_test.go
+++ b/internal/commands/storage/backup/backup_test.go
@@ -1,0 +1,8 @@
+package storagebackup
+
+const (
+	Title1 = "mock-storage-title1"
+	Title2 = "mock-storage-title2"
+	UUID1  = "0127dfd6-3884-4079-a948-3a8881df1a7a"
+	UUID2  = "012bde1d-f0e7-4bb2-9f4a-74e1f2b49c07"
+)

--- a/internal/commands/storage/backup/create.go
+++ b/internal/commands/storage/backup/create.go
@@ -1,4 +1,4 @@
-package storage
+package storagebackup
 
 import (
 	"fmt"

--- a/internal/commands/storage/backup/create_test.go
+++ b/internal/commands/storage/backup/create_test.go
@@ -1,4 +1,4 @@
-package storage
+package storagebackup
 
 import (
 	"testing"

--- a/internal/commands/storage/backup/restore.go
+++ b/internal/commands/storage/backup/restore.go
@@ -1,4 +1,4 @@
-package storage
+package storagebackup
 
 import (
 	"fmt"

--- a/internal/commands/storage/backup/restore_test.go
+++ b/internal/commands/storage/backup/restore_test.go
@@ -1,4 +1,4 @@
-package storage
+package storagebackup
 
 import (
 	"testing"


### PR DESCRIPTION
This syncs directory structure with command structure similarly than with server and database commands.