### PR TITLE
Return non-zero exit code if command execution fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Breaking**: Set non-zero exit code if command execution fails.
+
 ## [1.5.1] - 2022-07-15
 ### Fixed
 - On `server create`, mount OS disk by default on `virtio` bus. Previously default OS storage address was not explicit and varyed depending on template type.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ $ upctl server list
  003c9d77-0237-4ee7-b3a1-306efba456dc   server2              1xCPU-2GB   sg-sin1   started
 ```
 
+## Exit codes
+
+Exit code communicates success or the type and number of failures. Possible exit codes of `upctl` are:
+
+Exit code | Description
+--------- | -----------
+0         | Command(s) executed successfully.
+1 - 99    | Number of failed executions. For example, if stopping four servers and API returs error for one of the request, exit code will be 1.
+100 -     | Other, non-execution related, errors. For example, required flag missing.
+
 ## Examples
 
 Every command has a help and examples included and you can find all its options

--- a/cmd/upctl/main.go
+++ b/cmd/upctl/main.go
@@ -7,7 +7,6 @@ import (
 )
 
 func main() {
-	if err := core.BootstrapCLI(os.Args); err != nil {
-		os.Exit(1)
-	}
+	exitCode := core.Execute()
+	os.Exit(exitCode)
 }

--- a/internal/clierrors/client_error.go
+++ b/internal/clierrors/client_error.go
@@ -1,0 +1,8 @@
+package clierrors
+
+const UnspecifiedErrorCode int = 100
+
+// ClientError declares interface for errors known to the client that set specific error code.
+type ClientError interface {
+	ErrorCode() int
+}

--- a/internal/clierrors/command_failed.go
+++ b/internal/clierrors/command_failed.go
@@ -1,0 +1,22 @@
+package clierrors
+
+import "fmt"
+
+type CommandFailedError struct {
+	FailedCount int
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (err CommandFailedError) ErrorCode() int {
+	return min(err.FailedCount, 99)
+}
+
+func (err CommandFailedError) Error() string {
+	return fmt.Sprintf("Command execution failed for %d resource(s)", err.FailedCount)
+}

--- a/internal/commands/runcommand.go
+++ b/internal/commands/runcommand.go
@@ -18,6 +18,9 @@ var (
 )
 
 func commandRunE(command Command, service internal.AllServices, config *config.Config, args []string) error {
+	// Cobra validations were successful
+	command.Cobra().SilenceUsage = true
+
 	cmdLogger := logger.With("command", command.Cobra().CommandPath())
 	executor := NewExecutor(config, service, cmdLogger)
 	defer executor.Close()

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/UpCloudLtd/upcloud-cli/internal/clierrors"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/all"
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
@@ -124,8 +125,18 @@ func BuildCLI() cobra.Command {
 	return rootCmd
 }
 
-// BootstrapCLI is the CLI entrypoint
-func BootstrapCLI(args []string) error {
+// Execute is the application entrypoint. It returns the exit code that should be forwarded to the shell.
+func Execute() int {
 	rootCmd := BuildCLI()
-	return rootCmd.Execute()
+	err := rootCmd.Execute()
+
+	if err != nil {
+		if clierr, ok := err.(clierrors.ClientError); ok {
+			return clierr.ErrorCode()
+		}
+
+		return clierrors.UnspecifiedErrorCode
+	}
+
+	return 0
 }

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -132,3 +132,30 @@ func TestInputValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestExecute(t *testing.T) {
+	realArgs := os.Args
+	defer func() { os.Args = realArgs }()
+
+	for _, test := range []struct {
+		name     string
+		args     []string
+		expected int
+	}{
+		{
+			name:     "Successful command (upctl version)",
+			args:     []string{"upctl", "version"},
+			expected: 0,
+		},
+		{
+			name:     "Failing command (upctl server create)",
+			args:     []string{"upctl", "server", "create"},
+			expected: 100,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			os.Args = test.args
+			assert.Equal(t, test.expected, Execute())
+		})
+	}
+}

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/UpCloudLtd/upcloud-cli/internal/clierrors"
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 )
 
@@ -73,6 +74,20 @@ func Render(writer io.Writer, cfg *config.Config, commandOutputs ...Output) (err
 	}
 	if _, err := writer.Write(output); err != nil {
 		return err
+	}
+
+	// Count failed outputs
+	var failedCount = 0
+	for _, commandOutput := range commandOutputs {
+		if _, ok := commandOutput.(Error); ok {
+			failedCount++
+		}
+	}
+
+	if failedCount > 0 {
+		return &clierrors.CommandFailedError{
+			FailedCount: failedCount,
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Script to test this:

```bash
#!/bin/bash -x
prefix=exit-codes-test-
result=0

assert_exit_code() {
    actual=${1}
    expected=${2}

    if [ ${actual} -ne ${expected} ]; then
        echo "Assert failed: got ${actual}, expected ${expected}."
        result=$((result + 1))
    fi
}

./bin/upctl server create
assert_exit_code $? 100

./bin/upctl server create --hostname ${prefix}vm-1 --zone pl-waw1 --ssh-keys ~/.ssh/*.pub --wait
assert_exit_code $? 0

./bin/upctl server create --hostname ${prefix}vm-2 --zone pl-waw1 --ssh-keys ~/.ssh/*.pub --wait
assert_exit_code $? 0

./bin/upctl server stop ${prefix}vm-1 --wait
assert_exit_code $? 0

./bin/upctl server stop ${prefix}vm-1 ${prefix}vm-2 --wait
assert_exit_code $? 1

./bin/upctl server stop ${prefix}vm-1 ${prefix}vm-2 --wait
assert_exit_code $? 2

./bin/upctl server delete ${prefix}vm-1 ${prefix}vm-2 --delete-storages
assert_exit_code $? 0

exit ${result}

```