### PR TITLE
Build subcommands in resource specific base command

### DIFF
--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -11,9 +11,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/root"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/router"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/server"
-	serverfirewall "github.com/UpCloudLtd/upcloud-cli/internal/commands/server/firewall"
-	"github.com/UpCloudLtd/upcloud-cli/internal/commands/server/networkinterface"
-	serverstorage "github.com/UpCloudLtd/upcloud-cli/internal/commands/server/storage"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/storage"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/zone"
 	"github.com/UpCloudLtd/upcloud-cli/internal/config"
@@ -21,38 +18,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// BuildCommands is the main function that sets up the commands provided by upctl.
+// BuildCommands is the main function that sets up the top-level commands provided by upctl.
 func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
-	// Servers
-	serverCommand := commands.BuildCommand(server.BaseServerCommand(), rootCmd, conf)
-	commands.BuildCommand(server.ListCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.PlanListCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.ShowCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.StartCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.RestartCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.StopCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.CreateCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.ModifyCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.LoadCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.EjectCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(server.DeleteCommand(), serverCommand.Cobra(), conf)
-
-	// Server Network Interfaces
-	networkInterfaceCommand := commands.BuildCommand(networkinterface.BaseNetworkInterfaceCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(networkinterface.CreateCommand(), networkInterfaceCommand.Cobra(), conf)
-	commands.BuildCommand(networkinterface.ModifyCommand(), networkInterfaceCommand.Cobra(), conf)
-	commands.BuildCommand(networkinterface.DeleteCommand(), networkInterfaceCommand.Cobra(), conf)
-
-	// Server storage operations
-	serverStorageCommand := commands.BuildCommand(serverstorage.BaseServerStorageCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(serverstorage.AttachCommand(), serverStorageCommand.Cobra(), conf)
-	commands.BuildCommand(serverstorage.DetachCommand(), serverStorageCommand.Cobra(), conf)
-
-	// Server firewall operations
-	serverFirewallCommand := commands.BuildCommand(serverfirewall.BaseServerFirewallCommand(), serverCommand.Cobra(), conf)
-	commands.BuildCommand(serverfirewall.CreateCommand(), serverFirewallCommand.Cobra(), conf)
-	commands.BuildCommand(serverfirewall.DeleteCommand(), serverFirewallCommand.Cobra(), conf)
-	commands.BuildCommand(serverfirewall.ShowCommand(), serverFirewallCommand.Cobra(), conf)
+	commands.BuildCommand(server.BaseServerCommand(), rootCmd, conf)
 
 	// Storages
 	storageCommand := commands.BuildCommand(storage.BaseStorageCommand(), rootCmd, conf)

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -27,6 +27,7 @@ func New(name, usage string, examples ...string) *BaseCommand {
 // Command is the base command type for all commands.
 type Command interface {
 	InitCommand()
+	BuildSubCommands(*config.Config)
 	CobraCommand
 }
 
@@ -115,6 +116,8 @@ func BuildCommand(child Command, parent *cobra.Command, config *config.Config) C
 		return commandRunE(child, service, config, args)
 	}
 
+	child.BuildSubCommands(config)
+
 	return child
 }
 
@@ -139,10 +142,13 @@ func (s *BaseCommand) AddFlags(flags *pflag.FlagSet) {
 	})
 }
 
-// InitCommand can be overridden to handle flag registration.
-// A hook to handle flag registration.
+// InitCommand is a hook for handling flag registration and other initialization action.
 // The config values are not available during this hook. Register a cobra hook to use them. You can set defaults though.
 func (s *BaseCommand) InitCommand() {
+}
+
+// BuildSubCommands is a hook for handling possible sub-commands.
+func (s *BaseCommand) BuildSubCommands(*config.Config) {
 }
 
 // Cobra returns the underlying *cobra.Command

--- a/internal/commands/runcommand_test.go
+++ b/internal/commands/runcommand_test.go
@@ -28,6 +28,10 @@ func (m *mockNone) InitCommand() {
 	panic("implement me")
 }
 
+func (m *mockNone) BuildSubCommands(*config.Config) {
+	panic("implement me")
+}
+
 func (m *mockNone) Cobra() *cobra.Command {
 	return m.Command
 }
@@ -43,6 +47,10 @@ type mockSingle struct {
 }
 
 func (m *mockSingle) InitCommand() {
+	panic("implement me")
+}
+
+func (m *mockSingle) BuildSubCommands(*config.Config) {
 	panic("implement me")
 }
 
@@ -65,6 +73,10 @@ func (m *mockMulti) MaximumExecutions() int {
 }
 
 func (m *mockMulti) InitCommand() {
+	panic("implement me")
+}
+
+func (m *mockMulti) BuildSubCommands(*config.Config) {
 	panic("implement me")
 }
 
@@ -103,6 +115,10 @@ func (m *mockMultiResolver) MaximumExecutions() int {
 }
 
 func (m *mockMultiResolver) InitCommand() {
+	panic("implement me")
+}
+
+func (m *mockMultiResolver) BuildSubCommands(*config.Config) {
 	panic("implement me")
 }
 

--- a/internal/commands/server/firewall/server_firewall.go
+++ b/internal/commands/server/firewall/server_firewall.go
@@ -2,6 +2,7 @@ package serverfirewall
 
 import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 )
 
 // BaseServerFirewallCommand is the root command for all 'server firewall' commands
@@ -15,4 +16,10 @@ func BaseServerFirewallCommand() commands.Command {
 
 type serverFirewallCommand struct {
 	*commands.BaseCommand
+}
+
+func (s *serverFirewallCommand) BuildSubCommands(cfg *config.Config) {
+	commands.BuildCommand(CreateCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(DeleteCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(ShowCommand(), s.Cobra(), cfg)
 }

--- a/internal/commands/server/networkinterface/network_interface.go
+++ b/internal/commands/server/networkinterface/network_interface.go
@@ -3,6 +3,7 @@ package networkinterface
 import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands/ipaddress"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 )
 
@@ -15,6 +16,12 @@ func BaseNetworkInterfaceCommand() commands.Command {
 
 type networkInterfaceCommand struct {
 	*commands.BaseCommand
+}
+
+func (n *networkInterfaceCommand) BuildSubCommands(cfg *config.Config) {
+	commands.BuildCommand(CreateCommand(), n.Cobra(), cfg)
+	commands.BuildCommand(ModifyCommand(), n.Cobra(), cfg)
+	commands.BuildCommand(DeleteCommand(), n.Cobra(), cfg)
 }
 
 func mapIPAddressesToRequest(ipStrings []string) ([]request.CreateNetworkInterfaceIPAddress, error) {

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -5,6 +5,10 @@ import (
 	"time"
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	serverfirewall "github.com/UpCloudLtd/upcloud-cli/internal/commands/server/firewall"
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands/server/networkinterface"
+	serverstorage "github.com/UpCloudLtd/upcloud-cli/internal/commands/server/storage"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/service"
@@ -29,6 +33,24 @@ func BaseServerCommand() commands.Command {
 
 type serverCommand struct {
 	*commands.BaseCommand
+}
+
+func (s *serverCommand) BuildSubCommands(cfg *config.Config) {
+	commands.BuildCommand(ListCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(PlanListCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(ShowCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(StartCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(RestartCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(StopCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(CreateCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(ModifyCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(LoadCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(EjectCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(DeleteCommand(), s.Cobra(), cfg)
+
+	commands.BuildCommand(networkinterface.BaseNetworkInterfaceCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(serverstorage.BaseServerStorageCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(serverfirewall.BaseServerFirewallCommand(), s.Cobra(), cfg)
 }
 
 // waitForServerState waits for server to reach given state and updates given logline with wait progress. Finally, logline is updated with given msg and either done state or timeout warning.

--- a/internal/commands/server/storage/server_storage.go
+++ b/internal/commands/server/storage/server_storage.go
@@ -2,6 +2,7 @@ package serverstorage
 
 import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/config"
 )
 
 const (
@@ -15,4 +16,9 @@ func BaseServerStorageCommand() commands.Command {
 
 type serverStorageCommand struct {
 	*commands.BaseCommand
+}
+
+func (s *serverStorageCommand) BuildSubCommands(cfg *config.Config) {
+	commands.BuildCommand(AttachCommand(), s.Cobra(), cfg)
+	commands.BuildCommand(DetachCommand(), s.Cobra(), cfg)
 }


### PR DESCRIPTION
This is one idea on how to start cleaning up `internal/commands/all/all.go`. This would just distribute building of the commands to multiple places so not sure if this would be good or bad for code readability. Probably good to discuss also other approaches.