### PR TITLE
Fix errors in JSON and YAML outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Breaking**: Set non-zero exit code if command execution fails.
-- **Breaking**: Render servers IP addresses as array of objects in JSON and YAML outputs of `server show`.
+- **Breaking**: Render servers IP addresses as array of objects, instead of previous pretty-printed string, in JSON and YAML outputs of `server show`.
+- **Breaking**: Use key names from `json` field tag also in YAML output to have equal key names in JSON and YAML outputs. For example, `bootorder` key in server details will now be `boot_order` also in YAML output. As a side-effect data-types are limited to those supported by JSON. For example, timestamps will be presented as (double-quoted) strings. In addition, if command targets multiple resources, YAML output will now be a list, similarly than in JSON output, instead of previous multiple YAML documents.
 
 ## [1.5.1] - 2022-07-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Breaking**: Set non-zero exit code if command execution fails.
+- **Breaking**: Render servers IP addresses as array of objects in JSON and YAML outputs of `server show`.
 
 ## [1.5.1] - 2022-07-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `database delete` command.
 - Add `loadbalancer delete` command.
+- Add `Access` field to `storage show` output.
 
 ### Fixed
 - **Breaking**: Set non-zero exit code if command execution fails.
 - **Breaking**: Render servers IP addresses as array of objects, instead of previous pretty-printed string, in JSON and YAML outputs of `server show`.
 - **Breaking**: Use key names from `json` field tag also in YAML output to have equal key names in JSON and YAML outputs. For example, `bootorder` key in server details will now be `boot_order` also in YAML output. As a side-effect data-types are limited to those supported by JSON. For example, timestamps will be presented as (double-quoted) strings. In addition, if command targets multiple resources, YAML output will now be a list, similarly than in JSON output, instead of previous multiple YAML documents.
+- **Breaking**: In JSON and YAML output, `storage show` lists attached servers in `servers` list instead of `server` string.
 
 ## [1.5.1] - 2022-07-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Render servers IP addresses as array of objects, instead of previous pretty-printed string, in JSON and YAML outputs of `server show`.
 - **Breaking**: Use key names from `json` field tag also in YAML output to have equal key names in JSON and YAML outputs. For example, `bootorder` key in server details will now be `boot_order` also in YAML output. As a side-effect data-types are limited to those supported by JSON. For example, timestamps will be presented as (double-quoted) strings. In addition, if command targets multiple resources, YAML output will now be a list, similarly than in JSON output, instead of previous multiple YAML documents.
 - **Breaking**: In JSON and YAML output, `storage show` lists attached servers in `servers` list instead of `server` string.
+- **Breaking**: In JSON and YAML output, `network show` lists DHCP DNS values in list instead of string.
 
 ## [1.5.1] - 2022-07-15
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -53,5 +53,5 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/ini.v1 v1.51.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/internal/commands/network/show.go
+++ b/internal/commands/network/show.go
@@ -10,6 +10,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
 
 // ShowCommand creates the "network show" command
@@ -70,7 +71,7 @@ func (s *showCommand) Execute(exec commands.Executor, arg string) (output.Output
 				nip.Family,
 				nip.DHCP.Bool(),
 				nip.DHCPDefaultRoute.Bool(),
-				strings.Join(nip.DHCPDns, " "),
+				nip.DHCPDns,
 			})
 		}
 
@@ -83,7 +84,7 @@ func (s *showCommand) Execute(exec commands.Executor, arg string) (output.Output
 					{Key: "family", Header: "Family"},
 					{Key: "dhcp", Header: "DHCP", Format: output.BoolFormat},
 					{Key: "dhcp_default_route", Header: "DHCP Def Router", Format: output.BoolFormat},
-					{Key: "dhcp_dns", Header: "DHCP DNS"},
+					{Key: "dhcp_dns", Header: "DHCP DNS", Format: formatShowDHCPDNS},
 				},
 				Rows: networkRows,
 			},
@@ -121,4 +122,13 @@ func (s *showCommand) Execute(exec commands.Executor, arg string) (output.Output
 	}
 
 	return combined, nil
+}
+
+func formatShowDHCPDNS(val interface{}) (text.Colors, string, error) {
+	addresses, ok := val.([]string)
+	if !ok {
+		return nil, "", fmt.Errorf("cannot parse IP addresses from %T, expected []string", val)
+	}
+
+	return nil, ui.DefaultAddressColours.Sprint(strings.Join(addresses, " ")), nil
 }

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -377,11 +377,11 @@ func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 
 	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
 		{Title: "UUID", Value: res.UUID, Colour: ui.DefaultUUUIDColours},
-		{Title: "IP Addresses", Value: res, Format: formatIPAddresses},
+		{Title: "IP Addresses", Value: res, Format: formatCreateIPAddresses},
 	}}, nil
 }
 
-func formatIPAddresses(val interface{}) (text.Colors, string, error) {
+func formatCreateIPAddresses(val interface{}) (text.Colors, string, error) {
 	server, ok := val.(*upcloud.ServerDetails)
 	if !ok {
 		return nil, "", fmt.Errorf("cannot parse IP addresses from %T, expected *upcloud.ServerDetails", val)

--- a/internal/commands/storage/show_test.go
+++ b/internal/commands/storage/show_test.go
@@ -66,7 +66,8 @@ func TestStorageHumanOutput(t *testing.T) {
   Storage
     UUID:    01101f27-196f-47e9-a055-4e2e8bb3b419 
     Title:   test-1                               
-    type:    normal                               
+    Access:  private                              
+    Type:    normal                               
     State:   online                               
     Size:    10                                   
     Tier:    maxiops                              

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
-
-	"gopkg.in/yaml.v2"
 )
 
 // CombinedSection represents a single section of a combined output
@@ -23,11 +21,6 @@ type Combined []CombinedSection
 // MarshalJSON implements json.Marshaler
 func (m Combined) MarshalJSON() ([]byte, error) {
 	return json.MarshalIndent(flattenSections(m), "", "  ")
-}
-
-// MarshalYAML returns table output marshaled to YAML.
-func (m Combined) MarshalYAML() ([]byte, error) {
-	return yaml.Marshal(flattenSections(m))
 }
 
 func flattenSections(m Combined) map[string]interface{} {

--- a/internal/output/combined_test.go
+++ b/internal/output/combined_test.go
@@ -25,7 +25,7 @@ func TestCombined(t *testing.T) {
 			},
 			expectedHumanResult: "  \n  BAR\n    boz thisistest \n",
 			expectedJSONResult:  "{\n  \"test\": {\n    \"baz\": \"thisistest\"\n  }\n}",
-			expectedYAMLResult:  "test:\n  baz: thisistest\n",
+			expectedYAMLResult:  "test:\n    baz: thisistest\n",
 		},
 		{
 			name: "two sections",
@@ -43,7 +43,7 @@ func TestCombined(t *testing.T) {
 			},
 			expectedHumanResult: "  \n  BAR\n    boz thisistest1 \n\n  \n  BAR\n    boz thisistest2 \n",
 			expectedJSONResult:  "{\n  \"test1\": {\n    \"baz\": \"thisistest1\"\n  },\n  \"test2\": {\n    \"baz\": \"thisistest2\"\n  }\n}",
-			expectedYAMLResult:  "test1:\n  baz: thisistest1\ntest2:\n  baz: thisistest2\n",
+			expectedYAMLResult:  "test1:\n    baz: thisistest1\ntest2:\n    baz: thisistest2\n",
 		},
 		{
 			name: "two tables",
@@ -106,15 +106,15 @@ func TestCombined(t *testing.T) {
   ]
 }`,
 			expectedYAMLResult: `test1:
-- a: 1
-  c: 2a
-- a: "3"
-  c: 4
+    - a: 1
+      c: 2a
+    - a: "3"
+      c: 4
 test2:
-- aa: 1a
-  cc: 2
-- aa: 3
-  cc: "4"
+    - aa: 1a
+      cc: 2
+    - aa: 3
+      cc: "4"
 `,
 		},
 	}

--- a/internal/output/details.go
+++ b/internal/output/details.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
-	"gopkg.in/yaml.v2"
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 )
@@ -66,12 +65,6 @@ func mapSectionRows(rows []DetailRow) map[string]interface{} {
 		out[row.Key] = row.Value
 	}
 	return out
-}
-
-// MarshalYAML marshals details and returns the YAML as []byte
-// nb. does *not* implement yaml.Marshaler
-func (d Details) MarshalYAML() ([]byte, error) {
-	return yaml.Marshal(mapSections(d.Sections))
 }
 
 // MarshalHuman marshals details and returns a human readable []byte

--- a/internal/output/details_test.go
+++ b/internal/output/details_test.go
@@ -22,7 +22,7 @@ func TestDetails(t *testing.T) {
 			}}}},
 			expectedHumanResult: "  \n  BAR\n    boz thisistest \n",
 			expectedJSONResult:  "{\n  \"foo\": {\n    \"baz\": \"thisistest\"\n  }\n}",
-			expectedYAMLResult:  "foo:\n  baz: thisistest\n",
+			expectedYAMLResult:  "foo:\n    baz: thisistest\n",
 		},
 	}
 

--- a/internal/output/error.go
+++ b/internal/output/error.go
@@ -3,8 +3,6 @@ package output
 import (
 	"encoding/json"
 	"fmt"
-
-	"gopkg.in/yaml.v2"
 )
 
 // Error implements output.Command for a return value that is an error
@@ -22,19 +20,6 @@ func (e Error) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.MarshalIndent(marshaled, "", "  ")
-}
-
-// MarshalYAML implements output.Output, it marshals the value and returns the YAML as []byte
-// nb. does *not* implement yaml.Marshaler
-func (e Error) MarshalYAML() ([]byte, error) {
-	marshaled, err := e.MarshalRawMap()
-	if err != nil {
-		return yaml.Marshal(map[string]interface{}{
-			"error": err.Error(),
-		})
-	}
-
-	return yaml.Marshal(marshaled)
 }
 
 // MarshalHuman implements output.Output

--- a/internal/output/marshaledwithhumandetails.go
+++ b/internal/output/marshaledwithhumandetails.go
@@ -15,12 +15,6 @@ func (d MarshaledWithHumanDetails) MarshalJSON() ([]byte, error) {
 	return OnlyMarshaled{Value: d.Value}.MarshalJSON()
 }
 
-// MarshalYAML implements output.Output, it marshals the value and returns the YAML as []byte
-// nb. does *not* implement yaml.Marshaler
-func (d MarshaledWithHumanDetails) MarshalYAML() ([]byte, error) {
-	return OnlyMarshaled{Value: d.Value}.MarshalYAML()
-}
-
 // MarshalHuman implements output.Output
 // For MarshaledWithHumanDetails outputs, we return *only* the details part in humanized output
 func (d MarshaledWithHumanDetails) MarshalHuman() ([]byte, error) {

--- a/internal/output/marshaledwithhumandetails_test.go
+++ b/internal/output/marshaledwithhumandetails_test.go
@@ -62,7 +62,7 @@ func TestMarshaledWithHumanDetails(t *testing.T) {
 			},
 			expectedHumanResult: "  \n  Fake {mock} \n",
 			expectedJSONResult:  "{\n  \"String\": \"mock\"\n}",
-			expectedYAMLResult:  "string: mock\n",
+			expectedYAMLResult:  "String: mock\n",
 		},
 	}
 	for _, test := range marshaledWithHumanDetailsTests {

--- a/internal/output/marshaledwithhumanoutput.go
+++ b/internal/output/marshaledwithhumanoutput.go
@@ -2,8 +2,6 @@ package output
 
 import (
 	"errors"
-
-	"gopkg.in/yaml.v2"
 )
 
 // MarshaledWithHumanOutput implements output.Command for a return value that passes through raw marshaled JSON or YAML and only affects human output. Like MarshaledWithHumanDetails, but allows more complex output.
@@ -17,18 +15,6 @@ func (d MarshaledWithHumanOutput) MarshalJSON() ([]byte, error) {
 	return OnlyMarshaled{Value: d.Value}.MarshalJSON()
 }
 
-// MarshalYAML implements output.Output, it marshals the value and returns the YAML as []byte
-// nb. does *not* implement yaml.Marshaler
-func (d MarshaledWithHumanOutput) MarshalYAML() ([]byte, error) {
-	// Marshal to JSON and convert to YAML. This is to use key names from json field tags.
-	jsonBytes, err := OnlyMarshaled{Value: d.Value}.MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-
-	return jsonToYaml(jsonBytes)
-}
-
 // MarshalHuman implements output.Output
 // For MarshaledWithHumanDetails outputs, we return *only* the details part in humanized output
 func (d MarshaledWithHumanOutput) MarshalHuman() ([]byte, error) {
@@ -38,12 +24,4 @@ func (d MarshaledWithHumanOutput) MarshalHuman() ([]byte, error) {
 // MarshalRawMap implements output.Output
 func (d MarshaledWithHumanOutput) MarshalRawMap() (map[string]interface{}, error) {
 	return nil, errors.New("MarshaledWithHumanOutput output should not be used as part of multiple output, raw output is undefined")
-}
-
-func jsonToYaml(jsonIn []byte) ([]byte, error) {
-	var yamlObj interface{}
-	if err := yaml.Unmarshal(jsonIn, &yamlObj); err != nil {
-		return nil, err
-	}
-	return yaml.Marshal(yamlObj)
 }

--- a/internal/output/none.go
+++ b/internal/output/none.go
@@ -8,11 +8,6 @@ func (s None) MarshalJSON() ([]byte, error) {
 	return []byte{}, nil
 }
 
-// MarshalYAML implements output.Output
-func (s None) MarshalYAML() ([]byte, error) {
-	return []byte{}, nil
-}
-
 // MarshalHuman implements output.Output
 func (s None) MarshalHuman() ([]byte, error) {
 	return []byte{}, nil

--- a/internal/output/onlymarshaled.go
+++ b/internal/output/onlymarshaled.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
-	"gopkg.in/yaml.v2"
 )
 
 // OnlyMarshaled implements output.Command for a return value that is only displayed as raw marshaled in JSON and YAML
@@ -22,17 +20,6 @@ func (d OnlyMarshaled) MarshalJSON() ([]byte, error) {
 		}, "", "  ")
 	}
 	return json.MarshalIndent(d.Value, "", "  ")
-}
-
-// MarshalYAML implements output.Output, it marshals the value and returns the YAML as []byte
-// nb. does *not* implement yaml.Marshaler
-func (d OnlyMarshaled) MarshalYAML() ([]byte, error) {
-	if errValue, ok := d.Value.(error); ok {
-		return yaml.Marshal(map[string]interface{}{
-			"error": errValue.Error(),
-		})
-	}
-	return yaml.Marshal(d.Value)
 }
 
 // MarshalHuman implements output.Output

--- a/internal/output/onlymarshaled_test.go
+++ b/internal/output/onlymarshaled_test.go
@@ -30,7 +30,7 @@ func TestOnlyMarshaled(t *testing.T) {
 			name:               "struct",
 			input:              output.OnlyMarshaled{Value: struct{ String string }{"mock"}},
 			expectedJSONResult: "{\n  \"String\": \"mock\"\n}",
-			expectedYAMLResult: "string: mock\n",
+			expectedYAMLResult: "String: mock\n",
 		},
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -7,7 +7,6 @@ import (
 // Output represent output from a command that can be rendered as JSON, YAML or human-readable
 type Output interface {
 	json.Marshaler
-	MarshalYAML() ([]byte, error)
 	MarshalHuman() ([]byte, error)
 	MarshalRawMap() (map[string]interface{}, error)
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -28,7 +28,7 @@ func (c outputTestCase) Generate() func(t *testing.T) {
 			bytes, err = c.input.MarshalJSON()
 			assert.NoError(t, err)
 			assert.Equal(t, c.expectedJSONResult, string(bytes))
-			bytes, err = c.input.MarshalYAML()
+			bytes, err = output.JSONToYAML(bytes)
 			assert.NoError(t, err)
 			assert.Equal(t, c.expectedYAMLResult, string(bytes))
 		} else {
@@ -38,7 +38,7 @@ func (c outputTestCase) Generate() func(t *testing.T) {
 			bytes, err = c.input.MarshalJSON()
 			assert.EqualError(t, err, c.expectedErrorMessage)
 			assert.Len(t, bytes, 0)
-			bytes, err = c.input.MarshalYAML()
+			bytes, err = output.JSONToYAML(bytes)
 			assert.EqualError(t, err, c.expectedErrorMessage)
 			assert.Len(t, bytes, 0)
 		}

--- a/internal/output/raw.go
+++ b/internal/output/raw.go
@@ -10,11 +10,6 @@ func (s Raw) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("json output not supported")
 }
 
-// MarshalYAML implements output.Output
-func (s Raw) MarshalYAML() ([]byte, error) {
-	return nil, fmt.Errorf("yaml output not supported")
-}
-
 // MarshalHuman implements output.Output
 func (s Raw) MarshalHuman() ([]byte, error) {
 	return s, nil

--- a/internal/output/render_test.go
+++ b/internal/output/render_test.go
@@ -32,7 +32,7 @@ func TestRender(t *testing.T) {
 			input:               output.None{},
 			expectedHumanResult: "\n",
 			expectedJSONResult:  "\n",
-			expectedYAMLResult:  "\n",
+			expectedYAMLResult:  "",
 		},
 		{
 			name:                "marshaled",

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
-	"gopkg.in/yaml.v2"
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
 	"github.com/UpCloudLtd/upcloud-cli/internal/validation"
@@ -49,11 +48,6 @@ func (s Table) asListOfMaps() []map[string]interface{} {
 // MarshalJSON implements json.Marshaler
 func (s Table) MarshalJSON() ([]byte, error) {
 	return json.MarshalIndent(s.asListOfMaps(), "", "  ")
-}
-
-// MarshalYAML returns table output marshaled to YAML.
-func (s Table) MarshalYAML() ([]byte, error) {
-	return yaml.Marshal(s.asListOfMaps())
 }
 
 // MarshalHuman returns table output in a human-readable form

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -66,7 +66,7 @@ func TestTable(t *testing.T) {
   }
 ]`,
 			expectedYAMLResult: `- aa: 4.123456778901234
-  cc: 2001-01-01T12:00:00Z
+  cc: "2001-01-01T12:00:00Z"
 `,
 		},
 		{

--- a/internal/output/yaml.go
+++ b/internal/output/yaml.go
@@ -1,0 +1,18 @@
+package output
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+// JSONToYAML converts JSON bytes into YAML bytes. This allows using key names from JSON field tags also for YAML output. This has some side-effects (e.g., timestamps will be double-quoted in output) but this is lesser evil than adding yaml field tags everywhere in our Go types.
+func JSONToYAML(jsonIn []byte) ([]byte, error) {
+	if len(jsonIn) == 0 {
+		return []byte{}, nil
+	}
+
+	var yamlObj interface{}
+	if err := yaml.Unmarshal(jsonIn, &yamlObj); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(yamlObj)
+}


### PR DESCRIPTION
- [x] Developed on top of #156 
- [x] To decide: Is it OK to generate YAML output by _Marshal JSON → Unmarshal YAML → Marshal YAML_ as this has side-effects such as timestamps as (double quoted) strings.