### PR TITLE
Fix `network show` output for networks that contains a load balancer

### DIFF
--- a/internal/commands/loadbalancer/show.go
+++ b/internal/commands/loadbalancer/show.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/format"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
@@ -99,7 +100,7 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 								{Title: "Plan:", Value: lb.Plan},
 								{Title: "Zone:", Value: lb.Zone},
 								{Title: "DNS name", Value: lb.DNSName},
-								{Title: "Network name", Value: networkName, Format: ui.FormatPossiblyUnknownString},
+								{Title: "Network name", Value: networkName, Format: format.PossiblyUnknownString},
 								{Title: "Network UUID", Value: lb.NetworkUUID},
 								{Title: "Operational state:", Value: lb.OperationalState, Colour: commands.LoadBalancerOperationalStateColour(lb.OperationalState)},
 							},

--- a/internal/commands/network/show.go
+++ b/internal/commands/network/show.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/format"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
@@ -117,8 +118,8 @@ func (s *showCommand) Execute(exec commands.Executor, arg string) (output.Output
 				Columns: []output.TableColumn{
 					{Header: "UUID", Key: "uuid", Colour: ui.DefaultUUUIDColours},
 					{Header: "Title", Key: "title"},
-					{Header: "Hostname", Key: "hostname", Format: ui.FormatPossiblyUnknownString},
-					{Header: "State", Key: "state", Format: commands.FormatServerState},
+					{Header: "Hostname", Key: "hostname", Format: format.PossiblyUnknownString},
+					{Header: "State", Key: "state", Format: format.ServerState},
 				},
 				Rows: serverRows,
 			},

--- a/internal/commands/server/list.go
+++ b/internal/commands/server/list.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/format"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/service"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
@@ -84,7 +85,7 @@ func (ls *listCommand) ExecuteWithoutArguments(exec commands.Executor) (output.O
 		{Key: "hostname", Header: "Hostname"},
 		{Key: "plan", Header: "Plan"},
 		{Key: "zone", Header: "Zone"},
-		{Key: "state", Header: "State", Format: commands.FormatServerState},
+		{Key: "state", Header: "State", Format: format.ServerState},
 	}
 
 	if ls.showIPAddresses != "none" {

--- a/internal/commands/server/show.go
+++ b/internal/commands/server/show.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-cli/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/internal/format"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-cli/internal/ui"
@@ -126,7 +127,7 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 							{Title: "Title:", Key: "title", Value: server.Title},
 							{Title: "Plan:", Key: "plan", Value: planOutput},
 							{Title: "Zone:", Key: "zone", Value: server.Zone},
-							{Title: "State:", Key: "state", Value: server.State, Format: commands.FormatServerState},
+							{Title: "State:", Key: "state", Value: server.State, Format: format.ServerState},
 							{Title: "Simple Backup:", Key: "simple_backup", Value: server.SimpleBackup},
 							{Title: "Licence:", Key: "licence", Value: server.License},
 							{Title: "Metadata:", Key: "metadata", Value: server.Metadata.String()},

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -96,34 +96,6 @@ func LoadBalancerOperationalStateColour(state upcloud.LoadBalancerOperationalSta
 	}
 }
 
-// ServerStateColour is a helper mapping server states to colours
-func ServerStateColour(state string) text.Colors {
-	switch state {
-	case upcloud.ServerStateStarted:
-		return text.Colors{text.FgGreen}
-	case upcloud.ServerStateError:
-		return text.Colors{text.FgHiRed, text.Bold}
-	case upcloud.ServerStateMaintenance:
-		return text.Colors{text.FgYellow}
-	default:
-		return text.Colors{text.FgHiBlack}
-	}
-}
-
-// FormatServerState implements Format function for server states
-func FormatServerState(val interface{}) (text.Colors, string, error) {
-	state, ok := val.(string)
-	if !ok {
-		return nil, "", fmt.Errorf("cannot parse server state from %T, expected string", val)
-	}
-
-	if state == "" {
-		return ui.FormatPossiblyUnknownString(state)
-	}
-
-	return nil, ServerStateColour(state).Sprint(state), nil
-}
-
 // StorageStateColour is a helper mapping storage states to colours
 func StorageStateColour(state string) text.Colors {
 	switch state {

--- a/internal/format/common.go
+++ b/internal/format/common.go
@@ -1,0 +1,20 @@
+package format
+
+import (
+	"fmt"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+// PossiblyUnkonwnString outputs "Unknown" in light black if input value is an empty string, otherwise passesthrough the input value.
+func PossiblyUnknownString(val interface{}) (text.Colors, string, error) {
+	str, ok := val.(string)
+	if !ok {
+		return nil, "", fmt.Errorf("cannot parse %T, expected string", val)
+	}
+
+	if str == "" {
+		return nil, text.FgHiBlack.Sprint("unknown"), nil
+	}
+	return nil, str, nil
+}

--- a/internal/format/server.go
+++ b/internal/format/server.go
@@ -1,0 +1,36 @@
+package format
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+// serverStateColour is a helper mapping server states to colours
+func serverStateColour(state string) text.Colors {
+	switch state {
+	case upcloud.ServerStateStarted:
+		return text.Colors{text.FgGreen}
+	case upcloud.ServerStateError:
+		return text.Colors{text.FgHiRed, text.Bold}
+	case upcloud.ServerStateMaintenance:
+		return text.Colors{text.FgYellow}
+	default:
+		return text.Colors{text.FgHiBlack}
+	}
+}
+
+// ServerState implements Format function for server states
+func ServerState(val interface{}) (text.Colors, string, error) {
+	state, ok := val.(string)
+	if !ok {
+		return nil, "", fmt.Errorf("cannot parse server state from %T, expected string", val)
+	}
+
+	if state == "" {
+		return PossiblyUnknownString(state)
+	}
+
+	return nil, serverStateColour(state).Sprint(state), nil
+}

--- a/internal/ui/text.go
+++ b/internal/ui/text.go
@@ -59,16 +59,3 @@ func FormatTime(tv time.Time) string {
 	}
 	return tv.Format(time.RFC3339)
 }
-
-// FormatPossiblyUnkonwnString outputs "Unknown" in light black if input value is an empty string, otherwise passesthrough the input value.
-func FormatPossiblyUnknownString(val interface{}) (text.Colors, string, error) {
-	str, ok := val.(string)
-	if !ok {
-		return nil, "", fmt.Errorf("cannot parse %T, expected string", val)
-	}
-
-	if str == "" {
-		return nil, text.FgHiBlack.Sprint("unknown"), nil
-	}
-	return nil, str, nil
-}


### PR DESCRIPTION
To be rebased on top of linter fixes:
- #162 
- #164 