### PR TITLE
Chore: update all commands

### DIFF
--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -120,6 +120,7 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	loadbalancerCommand := commands.BuildCommand(loadbalancer.BaseLoadBalancerCommand(), rootCmd, conf)
 	commands.BuildCommand(loadbalancer.ListCommand(), loadbalancerCommand.Cobra(), conf)
 	commands.BuildCommand(loadbalancer.ShowCommand(), loadbalancerCommand.Cobra(), conf)
+	commands.BuildCommand(loadbalancer.DeleteCommand(), loadbalancerCommand.Cobra(), conf)
 
 	// Misc
 	commands.BuildCommand(

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -110,6 +110,7 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	commands.BuildCommand(database.PlansCommand(), databaseCommand.Cobra(), conf)
 	commands.BuildCommand(database.StartCommand(), databaseCommand.Cobra(), conf)
 	commands.BuildCommand(database.StopCommand(), databaseCommand.Cobra(), conf)
+	commands.BuildCommand(database.DeleteCommand(), databaseCommand.Cobra(), conf)
 
 	// Database connections
 	connectionsCommand := commands.BuildCommand(databaseconnection.BaseConnectionCommand(), databaseCommand.Cobra(), conf)


### PR DESCRIPTION
Add missing `loadbalancer delete` and `database delete` commands to `all.go`.