### PR TITLE
fix(changelog): add v2.0.0 link and use compare links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,18 +153,19 @@ Initial public beta release :tada:
 ### Added
 - Current feature set added! First internal release
 
-[Unreleased]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/UpCloudLtd/upcloud-cli/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.5.1...v2.0.0
+[1.5.1]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.1.3...v1.2.0
+[1.1.3]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.1.2...v1.1.3
+[1.1.2]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v0.6.0...v1.0.0
+[0.6.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v0.1.1...v0.5.0
+[0.1.1]: https://github.com/UpCloudLtd/upcloud-cli/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v0.1.0
-[0.1.1]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v0.1.1
-[0.5.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v0.5.0
-[0.6.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v0.6.0
-[1.0.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.0.0
-[1.1.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.1.0
-[1.1.1]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.1.1
-[1.1.2]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.1.2
-[1.1.3]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.1.3
-[1.2.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.2.0
-[1.3.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.3.0
-[1.4.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.4.0
-[1.5.0]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.5.0
-[1.5.1]: https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v1.5.1


### PR DESCRIPTION
This syncs release link targets and ordering with our other repos and with keep a changelog example.