### PR TITLE
 feat(storage): add `--wait` flag to import and templatise commands 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add `--wait` flag to `storage import` and `storage templatise` commands to wait until storage is in `online` state.
 - In JSON and YAML output of `storage import`: information on target storage is now available under `storage` key.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- In JSON and YAML output of `storage import`: information on target storage is now available under `storage` key.
+
 ### Fixed
-- In `storage list` output: capitalize zone column header and color storage state similarly than in `storage show`.
+- In human output of `storage list`: capitalize zone column header and color storage state similarly than in `storage show`.
+- In human output of `storage import`: output UUID of created storage, instead of storage import operation. No UUID is outputted if existing storage was used.
 
 ## [2.0.0] - 2022-08-30
 ### Added

--- a/internal/commands/storage/import.go
+++ b/internal/commands/storage/import.go
@@ -69,7 +69,7 @@ func (s *importCommand) InitCommand() {
 	flagSet := &pflag.FlagSet{}
 	flagSet.StringVar(&s.sourceLocation, "source-location", "", "Location of the source of the import. Can be a file or a URL.")
 	flagSet.StringVar(&s.existingStorageUUIDOrName, "storage", "", "Import to an existing storage. Storage must be large enough and must be undetached or the server where the storage is attached must be in shutdown state.")
-	config.AddToggleFlag(flagSet, &s.noWait, "no-wait", false, "Do not wait until the import finishes. Only applicable when importing from a remote URL.")
+	config.AddToggleFlag(flagSet, &s.noWait, "no-wait", false, "When importing from remote url, do not wait until the import finishes or storage is in online state. If set, command will exit after import process has been initialized.")
 	config.AddToggleFlag(flagSet, &s.wait, "wait", false, "Wait for storage to be in online state before returning.")
 	applyCreateFlags(flagSet, &s.createParams, defaultCreateParams)
 

--- a/internal/commands/storage/import.go
+++ b/internal/commands/storage/import.go
@@ -57,6 +57,7 @@ type importCommand struct {
 	sourceLocation            string
 	existingStorageUUIDOrName string
 	noWait                    config.OptionalBoolean
+	wait                      config.OptionalBoolean
 
 	createParams createParams
 
@@ -69,6 +70,7 @@ func (s *importCommand) InitCommand() {
 	flagSet.StringVar(&s.sourceLocation, "source-location", "", "Location of the source of the import. Can be a file or a URL.")
 	flagSet.StringVar(&s.existingStorageUUIDOrName, "storage", "", "Import to an existing storage. Storage must be large enough and must be undetached or the server where the storage is attached must be in shutdown state.")
 	config.AddToggleFlag(flagSet, &s.noWait, "no-wait", false, "Do not wait until the import finishes. Only applicable when importing from a remote URL.")
+	config.AddToggleFlag(flagSet, &s.wait, "wait", false, "Wait for storage to be in online state before returning.")
 	applyCreateFlags(flagSet, &s.createParams, defaultCreateParams)
 
 	s.AddFlags(flagSet)
@@ -221,7 +223,11 @@ func (s *importCommand) ExecuteWithoutArguments(exec commands.Executor) (output.
 			return commands.HandleError(exec, msg, statusUpdate.err)
 		case statusUpdate.complete:
 			// we're complete, clean up log and return the result
-			exec.PushProgressSuccess(msg)
+			if s.wait.Value() {
+				waitForStorageState(storageToImportTo.UUID, upcloud.StorageStateOnline, exec, msg)
+			} else {
+				exec.PushProgressSuccess(msg)
+			}
 
 			return getImportSuccessOutput(statusUpdate.result, storageToImportTo, s.existingStorageUUIDOrName == "")
 		case statusUpdate.bytesTransferred > 0:


### PR DESCRIPTION
Implements #174 and in addition:
- Add target storage info to machine readable `storage import` output
- Display UUID of created storage, if one was created, in human output of `storage import` command