### PR TITLE
feat(version): add OS and arch info to version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Include runtime operating system and architecture in `version` command output.
+
 ### Fixed
 - Fix commands in `server delete` usage examples.
 

--- a/internal/commands/root/version.go
+++ b/internal/commands/root/version.go
@@ -22,6 +22,8 @@ func (s *VersionCommand) ExecuteWithoutArguments(_ commands.Executor) (output.Ou
 					{Title: "Version:", Key: "version", Value: config.Version},
 					{Title: "Build date:", Key: "build_date", Value: config.BuildDate},
 					{Title: "Built with:", Key: "built_with", Value: runtime.Version()},
+					{Title: "System:", Key: "operating_system", Value: runtime.GOOS},
+					{Title: "Architecture:", Key: "architecture", Value: runtime.GOARCH},
 				},
 			},
 		},


### PR DESCRIPTION
We ask OS and architecture to be included in bug reports. Outputting these in the version command makes it easier for the user to provide these.