### PR TITLE
feat(database): add command to list db properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Print warning about unknown resource state before exiting when execution is interrupted with SIGINT.
 - Add `kubernetes nodegroup create`, `kubernetes nodegroup scale`, and `kubernetes nodegroup delete` commands (EXPERIMENTAL)
 - Added support for all shell completions provided by `cobra`.
+- Add `database properties` command to list database properties for given database type and `database properties show` command to show database property details.
 
 ### Changed
 - Remove custom bash completion logic and replace it with `completion` command provided by `cobra`. To do this while supporting args with whitespace, whitespace in completions is replaced with non-breaking spaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Print warning about unknown resource state before exiting when execution is interrupted with SIGINT.
 - Add `kubernetes nodegroup create`, `kubernetes nodegroup scale`, and `kubernetes nodegroup delete` commands (EXPERIMENTAL)
 - Added support for all shell completions provided by `cobra`.
-- Add `database properties` command to list database properties for given database type and `database properties show` command to show database property details.
+- Add `database properties <DB type>` command to list database properties for given database type and `database properties <DB type> show` command to show database property details.
 
 ### Changed
 - Remove custom bash completion logic and replace it with `completion` command provided by `cobra`. To do this while supporting args with whitespace, whitespace in completions is replaced with non-breaking spaces.

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands/account"
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands/database"
 	databaseconnection "github.com/UpCloudLtd/upcloud-cli/v2/internal/commands/database/connection"
+	databaseproperties "github.com/UpCloudLtd/upcloud-cli/v2/internal/commands/database/properties"
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands/ipaddress"
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands/kubernetes"
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands/kubernetes/nodegroup"
@@ -118,6 +119,10 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	connectionsCommand := commands.BuildCommand(databaseconnection.BaseConnectionCommand(), databaseCommand.Cobra(), conf)
 	commands.BuildCommand(databaseconnection.CancelCommand(), connectionsCommand.Cobra(), conf)
 	commands.BuildCommand(databaseconnection.ListCommand(), connectionsCommand.Cobra(), conf)
+
+	// Database connections
+	propertiesCommand := commands.BuildCommand(databaseproperties.PropertiesCommand(), databaseCommand.Cobra(), conf)
+	commands.BuildCommand(databaseproperties.ShowCommand(), propertiesCommand.Cobra(), conf)
 
 	// LoadBalancers
 	loadbalancerCommand := commands.BuildCommand(loadbalancer.BaseLoadBalancerCommand(), rootCmd, conf)

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -122,7 +122,17 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 
 	// Database connections
 	propertiesCommand := commands.BuildCommand(databaseproperties.PropertiesCommand(), databaseCommand.Cobra(), conf)
-	commands.BuildCommand(databaseproperties.ShowCommand(), propertiesCommand.Cobra(), conf)
+	for _, i := range []struct {
+		serviceName string
+		serviceType string
+	}{
+		{serviceName: "MySQL", serviceType: "mysql"},
+		{serviceName: "PostgreSQL", serviceType: "pg"},
+		{serviceName: "Redis", serviceType: "redis"},
+	} {
+		typeCommand := commands.BuildCommand(databaseproperties.DbTypeCommand(i.serviceType, i.serviceName), propertiesCommand.Cobra(), conf)
+		commands.BuildCommand(databaseproperties.ShowCommand(i.serviceType, i.serviceName), typeCommand.Cobra(), conf)
+	}
 
 	// LoadBalancers
 	loadbalancerCommand := commands.BuildCommand(loadbalancer.BaseLoadBalancerCommand(), rootCmd, conf)

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -130,7 +130,7 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 		{serviceName: "PostgreSQL", serviceType: "pg"},
 		{serviceName: "Redis", serviceType: "redis"},
 	} {
-		typeCommand := commands.BuildCommand(databaseproperties.DbTypeCommand(i.serviceType, i.serviceName), propertiesCommand.Cobra(), conf)
+		typeCommand := commands.BuildCommand(databaseproperties.DBTypeCommand(i.serviceType, i.serviceName), propertiesCommand.Cobra(), conf)
 		commands.BuildCommand(databaseproperties.ShowCommand(i.serviceType, i.serviceName), typeCommand.Cobra(), conf)
 	}
 

--- a/internal/commands/database/properties/format.go
+++ b/internal/commands/database/properties/format.go
@@ -48,7 +48,7 @@ func alternativesString(values []interface{}) string {
 	}
 
 	whitespace := " "
-	if maxStringLen(strs) > 15 {
+	if maxStringLen(strs) > 15 || len(strs) > 3 {
 		whitespace = "\n"
 	}
 

--- a/internal/commands/database/properties/format.go
+++ b/internal/commands/database/properties/format.go
@@ -1,0 +1,57 @@
+package databaseproperties
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+func formatAlternatives(val interface{}) (text.Colors, string, error) {
+	if val == nil {
+		return nil, "", nil
+	}
+
+	if stringVal, ok := val.(string); ok {
+		return nil, stringVal, nil
+	}
+
+	if ifaceSliceVal, ok := val.([]interface{}); ok {
+		return nil, alternativesString(ifaceSliceVal), nil
+	}
+
+	return nil, fmt.Sprintf("%+v", val), nil
+}
+
+func maxStringLen(strings []string) int {
+	max := 0
+	for _, str := range strings {
+		if strLen := len(str); strLen > max {
+			max = strLen
+		}
+	}
+	return max
+}
+
+func alternativesString(values []interface{}) string {
+	if len(values) == 0 {
+		return ""
+	}
+
+	if len(values) == 1 {
+		return fmt.Sprintf("%+v", values[0])
+	}
+
+	strs := make([]string, len(values))
+	for i, value := range values {
+		strs[i] = fmt.Sprintf("%+v", value)
+	}
+
+	whitespace := " "
+	if maxStringLen(strs) > 15 {
+		whitespace = "\n"
+	}
+
+	str := strings.Join(strs[:len(strs)-1], ","+whitespace)
+	return str + fmt.Sprintf(" or%s%s", whitespace, strs[len(values)-1])
+}

--- a/internal/commands/database/properties/properties.go
+++ b/internal/commands/database/properties/properties.go
@@ -1,6 +1,8 @@
 package databaseproperties
 
 import (
+	"sort"
+
 	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
 	"github.com/UpCloudLtd/upcloud-cli/internal/format"
 	"github.com/UpCloudLtd/upcloud-cli/internal/output"
@@ -41,6 +43,12 @@ func (s *propertiesCommand) Execute(exec commands.Executor, serviceType string) 
 			enumOrExample,
 		})
 	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		iKey := rows[i][0].(string)
+		jKey := rows[j][0].(string)
+		return iKey < jKey
+	})
 
 	return output.MarshaledWithHumanOutput{
 		Value: properties,

--- a/internal/commands/database/properties/properties.go
+++ b/internal/commands/database/properties/properties.go
@@ -1,0 +1,57 @@
+package databaseproperties
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/format"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+)
+
+// PropertiesCommand creates the "database properties" command
+func PropertiesCommand() commands.Command {
+	return &propertiesCommand{
+		BaseCommand: commands.New("properties", "List available properties for given database type", "upctl database properties pg", "upctl database properties mysql"),
+	}
+}
+
+type propertiesCommand struct {
+	*commands.BaseCommand
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *propertiesCommand) Execute(exec commands.Executor, serviceType string) (output.Output, error) {
+	svc := exec.All()
+	dbType, err := svc.GetManagedDatabaseServiceType(&request.GetManagedDatabaseServiceTypeRequest{Type: serviceType})
+	if err != nil {
+		return nil, err
+	}
+
+	properties := dbType.Properties
+	rows := []output.TableRow{}
+	for key, details := range properties {
+		enumOrExample := details.Enum
+		if enumOrExample == nil {
+			enumOrExample = details.Example
+		}
+
+		rows = append(rows, output.TableRow{
+			key,
+			details.CreateOnly,
+			details.Type,
+			enumOrExample,
+		})
+	}
+
+	return output.MarshaledWithHumanOutput{
+		Value: properties,
+		Output: output.Table{
+			Columns: []output.TableColumn{
+				{Key: "property", Header: "Property"},
+				{Key: "createOnly", Header: "Create only", Format: format.Boolean},
+				{Key: "type", Header: "Type", Format: formatAlternatives},
+				{Key: "example", Header: "Example", Format: formatAlternatives},
+			},
+			Rows: rows,
+		},
+	}, nil
+}

--- a/internal/commands/database/properties/properties.go
+++ b/internal/commands/database/properties/properties.go
@@ -3,10 +3,10 @@ package databaseproperties
 import (
 	"sort"
 
-	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
-	"github.com/UpCloudLtd/upcloud-cli/internal/format"
-	"github.com/UpCloudLtd/upcloud-cli/internal/output"
-	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/format"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
+	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/request"
 )
 
 // PropertiesCommand creates the "database properties" command
@@ -23,7 +23,7 @@ type propertiesCommand struct {
 // Execute implements commands.MultipleArgumentCommand
 func (s *propertiesCommand) Execute(exec commands.Executor, serviceType string) (output.Output, error) {
 	svc := exec.All()
-	dbType, err := svc.GetManagedDatabaseServiceType(&request.GetManagedDatabaseServiceTypeRequest{Type: serviceType})
+	dbType, err := svc.GetManagedDatabaseServiceType(exec.Context(), &request.GetManagedDatabaseServiceTypeRequest{Type: serviceType})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/database/properties/properties.go
+++ b/internal/commands/database/properties/properties.go
@@ -1,12 +1,7 @@
 package databaseproperties
 
 import (
-	"sort"
-
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands"
-	"github.com/UpCloudLtd/upcloud-cli/v2/internal/format"
-	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
-	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/request"
 )
 
 // PropertiesCommand creates the "database properties" command
@@ -18,48 +13,4 @@ func PropertiesCommand() commands.Command {
 
 type propertiesCommand struct {
 	*commands.BaseCommand
-}
-
-// Execute implements commands.MultipleArgumentCommand
-func (s *propertiesCommand) Execute(exec commands.Executor, serviceType string) (output.Output, error) {
-	svc := exec.All()
-	dbType, err := svc.GetManagedDatabaseServiceType(exec.Context(), &request.GetManagedDatabaseServiceTypeRequest{Type: serviceType})
-	if err != nil {
-		return nil, err
-	}
-
-	properties := dbType.Properties
-	rows := []output.TableRow{}
-	for key, details := range properties {
-		enumOrExample := details.Enum
-		if enumOrExample == nil {
-			enumOrExample = details.Example
-		}
-
-		rows = append(rows, output.TableRow{
-			key,
-			details.CreateOnly,
-			details.Type,
-			enumOrExample,
-		})
-	}
-
-	sort.Slice(rows, func(i, j int) bool {
-		iKey := rows[i][0].(string)
-		jKey := rows[j][0].(string)
-		return iKey < jKey
-	})
-
-	return output.MarshaledWithHumanOutput{
-		Value: properties,
-		Output: output.Table{
-			Columns: []output.TableColumn{
-				{Key: "property", Header: "Property"},
-				{Key: "createOnly", Header: "Create only", Format: format.Boolean},
-				{Key: "type", Header: "Type", Format: formatAlternatives},
-				{Key: "example", Header: "Example", Format: formatAlternatives},
-			},
-			Rows: rows,
-		},
-	}, nil
 }

--- a/internal/commands/database/properties/show.go
+++ b/internal/commands/database/properties/show.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/completion"
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/format"
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
 	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/request"
@@ -12,13 +13,15 @@ import (
 // ShowCommand creates the "database properties <serviceType> show" command
 func ShowCommand(serviceType string, serviceName string) commands.Command {
 	return &showCommand{
-		BaseCommand: commands.New("show", fmt.Sprintf("Show %s database property details", serviceName), fmt.Sprintf("upctl database properties %s show version", serviceType)),
-		serviceType: serviceType,
+		BaseCommand:      commands.New("show", fmt.Sprintf("Show %s database property details", serviceName), fmt.Sprintf("upctl database properties %s show version", serviceType)),
+		serviceType:      serviceType,
+		DatabaseProperty: completion.DatabaseProperty{ServiceType: serviceType},
 	}
 }
 
 type showCommand struct {
 	*commands.BaseCommand
+	completion.DatabaseProperty
 	serviceType string
 }
 

--- a/internal/commands/database/properties/show.go
+++ b/internal/commands/database/properties/show.go
@@ -1,0 +1,88 @@
+package databaseproperties
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/internal/format"
+	"github.com/UpCloudLtd/upcloud-cli/internal/output"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+	"github.com/spf13/pflag"
+)
+
+// ShowCommand creates the "database properties show" command
+func ShowCommand() commands.Command {
+	return &showCommand{
+		BaseCommand: commands.New("show", "Show database property details", "upctl database properties show --db=pg version", "upctl database properties --db=pg version pg_stat_statements_track"),
+	}
+}
+
+type showCommand struct {
+	*commands.BaseCommand
+	dbServiceType string
+}
+
+// InitCommand implements Command.InitCommand
+func (s *showCommand) InitCommand() {
+	flags := &pflag.FlagSet{}
+	flags.StringVar(&s.dbServiceType, "db", "", "Database service type")
+	s.AddFlags(flags)
+	_ = s.Cobra().MarkFlagRequired("db")
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *showCommand) Execute(exec commands.Executor, key string) (output.Output, error) {
+	svc := exec.All()
+	dbType, err := svc.GetManagedDatabaseServiceType(&request.GetManagedDatabaseServiceTypeRequest{Type: s.dbServiceType})
+	if err != nil {
+		return nil, err
+	}
+
+	details, ok := dbType.Properties[key]
+	if !ok {
+		return nil, fmt.Errorf(`no property "%s" available for %s database`, key, s.dbServiceType)
+	}
+
+	rows := []output.DetailRow{
+		{Title: "Key:", Key: "key", Value: key},
+		{Title: "Title:", Key: "title", Value: details.Title},
+		{Title: "Description:", Key: "description", Value: details.Description},
+		{Title: "Help message:", Key: "user_error", Value: details.UserError},
+		{Title: "Create only:", Key: "createOnly", Value: details.CreateOnly, Format: format.Boolean},
+		{Title: "Type:", Key: "type", Value: details.Type, Format: formatAlternatives},
+		{Title: "Default:", Key: "default", Value: details.Default},
+		{Title: "Possible values:", Key: "enum", Value: details.Enum, Format: formatAlternatives},
+		{Title: "Pattern:", Key: "pattern", Value: details.Pattern},
+		{Title: "Max length:", Key: "maxLength", Value: details.MaxLength},
+		{Title: "Min length:", Key: "minLength", Value: details.MinLength},
+	}
+
+	return output.Details{
+		Sections: []output.DetailSection{
+			{
+				Rows: filterOutEmptyRows(rows),
+			},
+		},
+	}, nil
+}
+
+func filterOutEmptyRows(rows []output.DetailRow) []output.DetailRow {
+	nonEmpty := []output.DetailRow{}
+	for _, row := range rows {
+		if row.Value == nil {
+			continue
+		}
+
+		if val, ok := row.Value.(string); ok && val == "" {
+			continue
+		}
+
+		if val, ok := row.Value.(int); ok && val == 0 {
+			continue
+		}
+
+		nonEmpty = append(nonEmpty, row)
+	}
+
+	return nonEmpty
+}

--- a/internal/commands/database/properties/show.go
+++ b/internal/commands/database/properties/show.go
@@ -3,10 +3,10 @@ package databaseproperties
 import (
 	"fmt"
 
-	"github.com/UpCloudLtd/upcloud-cli/internal/commands"
-	"github.com/UpCloudLtd/upcloud-cli/internal/format"
-	"github.com/UpCloudLtd/upcloud-cli/internal/output"
-	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/format"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
+	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/request"
 	"github.com/spf13/pflag"
 )
 
@@ -33,7 +33,7 @@ func (s *showCommand) InitCommand() {
 // Execute implements commands.MultipleArgumentCommand
 func (s *showCommand) Execute(exec commands.Executor, key string) (output.Output, error) {
 	svc := exec.All()
-	dbType, err := svc.GetManagedDatabaseServiceType(&request.GetManagedDatabaseServiceTypeRequest{Type: s.dbServiceType})
+	dbType, err := svc.GetManagedDatabaseServiceType(exec.Context(), &request.GetManagedDatabaseServiceTypeRequest{Type: s.dbServiceType})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/database/properties/type.go
+++ b/internal/commands/database/properties/type.go
@@ -11,7 +11,7 @@ import (
 )
 
 // creates the "database properties <serviceType>" command
-func DbTypeCommand(serviceType string, serviceName string) commands.Command {
+func DBTypeCommand(serviceType string, serviceName string) commands.Command {
 	return &dbTypeCommand{
 		BaseCommand: commands.New(serviceType, fmt.Sprintf("List available properties for %s databases", serviceName), fmt.Sprintf("upctl database properties %s", serviceType)),
 		serviceType: serviceType,

--- a/internal/commands/database/properties/type.go
+++ b/internal/commands/database/properties/type.go
@@ -13,7 +13,7 @@ import (
 // creates the "database properties <serviceType>" command
 func DbTypeCommand(serviceType string, serviceName string) commands.Command {
 	return &dbTypeCommand{
-		BaseCommand: commands.New(serviceType, fmt.Sprintf("List available properties for %s database", serviceName), fmt.Sprintf("upctl database properties %s", serviceType)),
+		BaseCommand: commands.New(serviceType, fmt.Sprintf("List available properties for %s databases", serviceName), fmt.Sprintf("upctl database properties %s", serviceType)),
 		serviceType: serviceType,
 	}
 }

--- a/internal/commands/database/properties/type.go
+++ b/internal/commands/database/properties/type.go
@@ -1,0 +1,68 @@
+package databaseproperties
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/format"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
+	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/request"
+)
+
+// creates the "database properties <serviceType>" command
+func DbTypeCommand(serviceType string, serviceName string) commands.Command {
+	return &dbTypeCommand{
+		BaseCommand: commands.New(serviceType, fmt.Sprintf("List available properties for %s database", serviceName), fmt.Sprintf("upctl database properties %s", serviceType)),
+		serviceType: serviceType,
+	}
+}
+
+type dbTypeCommand struct {
+	*commands.BaseCommand
+	serviceType string
+}
+
+// Execute implements commands.NoArgumentCommand
+func (s *dbTypeCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
+	svc := exec.All()
+	dbType, err := svc.GetManagedDatabaseServiceType(exec.Context(), &request.GetManagedDatabaseServiceTypeRequest{Type: s.serviceType})
+	if err != nil {
+		return nil, err
+	}
+
+	properties := dbType.Properties
+	rows := []output.TableRow{}
+	for key, details := range properties {
+		enumOrExample := details.Enum
+		if enumOrExample == nil {
+			enumOrExample = details.Example
+		}
+
+		rows = append(rows, output.TableRow{
+			key,
+			details.CreateOnly,
+			details.Type,
+			enumOrExample,
+		})
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		iKey := rows[i][0].(string)
+		jKey := rows[j][0].(string)
+		return iKey < jKey
+	})
+
+	return output.MarshaledWithHumanOutput{
+		Value: properties,
+		Output: output.Table{
+			Columns: []output.TableColumn{
+				{Key: "property", Header: "Property"},
+				{Key: "createOnly", Header: "Create only", Format: format.Boolean},
+				{Key: "type", Header: "Type", Format: formatAlternatives},
+				{Key: "example", Header: "Example", Format: formatAlternatives},
+			},
+			Rows: rows,
+		},
+	}, nil
+}

--- a/internal/completion/database.go
+++ b/internal/completion/database.go
@@ -2,6 +2,7 @@ package completion
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/service"
 	"github.com/UpCloudLtd/upcloud-go-api/v5/upcloud/request"
@@ -42,6 +43,29 @@ func (s DatabaseType) CompleteArgument(ctx context.Context, svc service.AllServi
 	var vals []string
 	for _, t := range dbTypes {
 		vals = append(vals, t.Name)
+	}
+	return MatchStringPrefix(vals, toComplete, true), cobra.ShellCompDirectiveNoFileComp
+}
+
+// DatabaseProperty implements argument completion for database properties.
+type DatabaseProperty struct {
+	ServiceType string
+}
+
+// make sure DatabaseType implements the interface
+var _ Provider = DatabaseProperty{}
+
+// CompleteArgument implements completion.Provider
+func (s DatabaseProperty) CompleteArgument(ctx context.Context, svc service.AllServices, toComplete string) ([]string, cobra.ShellCompDirective) {
+	dbType, err := svc.GetManagedDatabaseServiceType(ctx, &request.GetManagedDatabaseServiceTypeRequest{Type: s.ServiceType})
+	if err != nil {
+		return None(toComplete)
+	}
+
+	properties := dbType.Properties
+	var vals []string
+	for key, details := range properties {
+		vals = append(vals, fmt.Sprintf("%s\t%s", key, details.Description))
 	}
 	return MatchStringPrefix(vals, toComplete, true), cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/completion/database.go
+++ b/internal/completion/database.go
@@ -65,7 +65,12 @@ func (s DatabaseProperty) CompleteArgument(ctx context.Context, svc service.AllS
 	properties := dbType.Properties
 	var vals []string
 	for key, details := range properties {
-		vals = append(vals, fmt.Sprintf("%s\t%s", key, details.Description))
+		description := details.Title
+		if description == key && details.Description != "" {
+			description = details.Description
+		}
+
+		vals = append(vals, fmt.Sprintf("%s\t%s", key, description))
 	}
 	return MatchStringPrefix(vals, toComplete, true), cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/completion/helpers.go
+++ b/internal/completion/helpers.go
@@ -5,13 +5,13 @@ import (
 	"strings"
 )
 
-var oneOrMoreWhitespace = regexp.MustCompile(`\s+`)
+var oneOrMoreSpace = regexp.MustCompile(` +`)
 
 // RemoveWordBreaks replaces all whitespaces in input strings with non-breaking spaces to prevent bash from splitting completion with whitespace into multiple completions.
 //
 // This hack allows us to use cobras built-in completion logic and can be removed once cobra supports whitespace in bash completions (See https://github.com/spf13/cobra/issues/1740).
 func RemoveWordBreaks(input string) string {
-	return oneOrMoreWhitespace.ReplaceAllString(input, "\u00A0")
+	return oneOrMoreSpace.ReplaceAllString(input, "\u00A0")
 }
 
 // MatchStringPrefix returns a list of string in vals which have a prefix as specified in key. Quotes are removed from key and output strings are escaped according to completion rules


### PR DESCRIPTION
Examples usage:

```
$ upctl db properties pg

 Property                              Create only   Type              Example                                              
───────────────────────────────────── ───────────── ───────────────── ──────────────────────────────────────────────────────
 admin_password                        yes           string or null    z66o9QXqKM                                           
 admin_username                        yes           string or null    avnadmin                                             
 automatic_utility_network_ip_filter   no            boolean                                                                
 autovacuum_analyze_scale_factor       no            number                                                                 
 autovacuum_analyze_threshold          no            integer                                                                
 autovacuum_freeze_max_age             no            integer           2e+08                                                
 autovacuum_max_workers                no            integer                                                                
 autovacuum_naptime                    no            integer                                                                

[...rest of the output omitted]

$ upctl db properties pg show admin_username admin_password
  
  Key:          admin_username                                                                                                           
  Title:        Custom username for admin user. This must be set only when a new service is being created.                               
  Help message: Must consist of alpha-numeric characters, dots, underscores or dashes, may not start with dash or dot, max 64 characters 
  Create only:  yes                                                                                                                      
  Type:         string or null                                                                                                           
  Pattern:      ^[_A-Za-z0-9][-._A-Za-z0-9]{0,63}$                                                                                       
  Max length:   64                                                                                                                       
  
  Key:          admin_password                                                                                                        
  Title:        Custom password for admin user. Defaults to random string. This must be set only when a new service is being created. 
  Help message: Must consist of alpha-numeric characters, underscores or dashes                                                       
  Create only:  yes                                                                                                                   
  Type:         string or null                                                                                                        
  Pattern:      ^[a-zA-Z0-9-_]+$                                                                                                      
  Max length:   256                                                                                                                   
  Min length:   8                                                                                                                     

```