### PR TITLE
feat(containers): use alpine as base to have shell in our images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
-      - GO_MODULE_NAME=github.com/UpCloudLtd/upcloud-cli
+      - GO_MODULE_NAME=github.com/UpCloudLtd/upcloud-cli/v2
     goos:
       - linux
       - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -214,3 +214,4 @@ dockers:
     - "--label=org.opencontainers.image.title=upctl"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/UpCloudLtd/upcloud-cli.git"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Suppress positional argument filename completion for commands without specific completions.
 - In `database list` output: if database has no title, database name is displayed in the title cell instead of leaving the cell empty, similarly than in the hub.
 - Version information is parsed from `BuildInfo` when `upctl` binary was built without specifying `-ldflags` to define value for `.../config.Version`.
+- Use alpine as base image for `upcloud/upctl` container image. This adds sh and other OS tools to the image and thus makes it more suitable for usage in CI systems.
 
 ### Fixed
 - Remove debug leftover print from IP address completions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.18-alpine3.16 as build
 
-RUN apk add --update --no-cache ca-certificates make
+RUN apk add --update --no-cache ca-certificates git make
 
 WORKDIR /go/upctl/
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
-FROM golang:1.18-buster as builder
-RUN apt-get -y install ca-certificates
+FROM golang:1.18-alpine3.16 as build
+
+RUN apk add --update --no-cache ca-certificates make
+
 WORKDIR /go/upctl/
 COPY . .
 RUN make build-dockerised
 
-FROM scratch
-LABEL org.label-schema.vcs-url="https://github.com/UpCloudLtd/upcloud-cli"
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /go/upctl/bin/*dockerised-linux-amd64 /upctl
 
-ENTRYPOINT ["/upctl"]
+FROM alpine:3.16
+
+LABEL org.label-schema.vcs-url="https://github.com/UpCloudLtd/upcloud-cli"
+
+RUN apk add --update --no-cache ca-certificates
+
+COPY --from=build /go/upctl/bin/*dockerised-linux-amd64 /bin/upctl
+
+ENTRYPOINT ["/bin/upctl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,7 @@ RUN make build-dockerised
 
 FROM alpine:3.16
 
-LABEL org.label-schema.vcs-url="https://github.com/UpCloudLtd/upcloud-cli"
-
 RUN apk add --update --no-cache ca-certificates
-
 COPY --from=build /go/upctl/bin/*dockerised-linux-amd64 /bin/upctl
 
 ENTRYPOINT ["/bin/upctl"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,5 @@
 FROM alpine:3.16
 
-LABEL org.label-schema.vcs-url="https://github.com/UpCloudLtd/upcloud-cli"
-
 RUN apk add --update --no-cache ca-certificates
 COPY upctl /bin/upctl
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,11 +1,8 @@
-FROM golang:1.18-buster as builder
-RUN apt-get -y install ca-certificates
-WORKDIR /go/upctl/
-COPY . .
+FROM alpine:3.16
 
-FROM scratch
 LABEL org.label-schema.vcs-url="https://github.com/UpCloudLtd/upcloud-cli"
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /go/upctl/upctl /upctl
 
-ENTRYPOINT ["/upctl"]
+RUN apk add --update --no-cache ca-certificates
+COPY upctl /bin/upctl
+
+ENTRYPOINT ["/bin/upctl"]


### PR DESCRIPTION
This makes the `upcloud/upctl` container more suitable for usage in CI pipelines. This also adds ~5 MB (size of `alpine:3.16` vs. `scratch`) to the image size and thus the image size will be ~16 MB in total.