### PR TITLE
feat(loadbalancer): add `plans` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add `kubernetes create`, `kubernetes delete`, `kubernetes list`, `kubernetes show`, `kubernetes versions` commands
+- Add `loadbalancer plans` command for listing available LB plans
 
 ## [2.3.0] - 2022-11-11
 ### Added

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -123,6 +123,7 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	commands.BuildCommand(loadbalancer.ListCommand(), loadbalancerCommand.Cobra(), conf)
 	commands.BuildCommand(loadbalancer.ShowCommand(), loadbalancerCommand.Cobra(), conf)
 	commands.BuildCommand(loadbalancer.DeleteCommand(), loadbalancerCommand.Cobra(), conf)
+	commands.BuildCommand(loadbalancer.PlansCommand(), loadbalancerCommand.Cobra(), conf)
 
 	// Kubernetes
 	kubernetesCommand := commands.BuildCommand(kubernetes.BaseKubernetesCommand(), rootCmd, conf)

--- a/internal/commands/loadbalancer/plans.go
+++ b/internal/commands/loadbalancer/plans.go
@@ -1,0 +1,48 @@
+package loadbalancer
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
+)
+
+// PlansCommand creates the "loadbalancer plans" command
+func PlansCommand() commands.Command {
+	return &plansCommand{
+		BaseCommand: commands.New("plans", "List available load balancer plans", "upctl loadbalancer plans"),
+	}
+}
+
+type plansCommand struct {
+	*commands.BaseCommand
+}
+
+// Execute implements commands.NoArgumentCommand
+func (s *plansCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
+	svc := exec.All()
+	plans, err := svc.GetLoadBalancerPlans(&request.GetLoadBalancerPlansRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	rows := []output.TableRow{}
+	for _, plan := range plans {
+		rows = append(rows, output.TableRow{
+			plan.Name,
+			plan.PerServerMaxSessions,
+			plan.ServerNumber,
+		})
+	}
+
+	return output.MarshaledWithHumanOutput{
+		Value: plans,
+		Output: output.Table{
+			Columns: []output.TableColumn{
+				{Key: "name", Header: "Name"},
+				{Key: "per_server_max_sessions", Header: "Max sessions per server"},
+				{Key: "server_number", Header: "Server count"},
+			},
+			Rows: rows,
+		},
+	}, nil
+}


### PR DESCRIPTION
Example output:

```txt
$ upctl lb plans

 Name               Max sessions per server   Server count 
────────────────── ───────────────────────── ──────────────
 development                           1000              1 
 production-small                     50000              2 

```