### PR TITLE
refactor(kubernetes): use conversion function instead of generics for node-groups

### DIFF
--- a/internal/commands/kubernetes/create.go
+++ b/internal/commands/kubernetes/create.go
@@ -78,7 +78,7 @@ func processNodeGroup(in string) (upcloud.KubernetesNodeGroup, error) {
 		return ng, err
 	}
 
-	return nodegroup.ProcessNodeGroupParams[upcloud.KubernetesNodeGroup](p)
+	return nodegroup.ProcessNodeGroupParams(p)
 }
 
 type createCommand struct {


### PR DESCRIPTION
This is to prevent linter from panicking because of the composite type.