### PR TITLE
feat(containers): add `jq` to the container image and publish it also to ghcr.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: GitHub Container Registry Login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -207,6 +207,10 @@ dockers:
     - "upcloud/upctl:{{ .Tag }}"
     - "upcloud/upctl:{{ .Major }}"
     - "upcloud/upctl:{{ .Major }}.{{ .Minor }}"
+    - "ghcr.io/upcloudltd/upctl:latest"
+    - "ghcr.io/upcloudltd/upctl:{{ .Tag }}"
+    - "ghcr.io/upcloudltd/upctl:{{ .Major }}"
+    - "ghcr.io/upcloudltd/upctl:{{ .Major }}.{{ .Minor }}"
 
     build_flag_templates:
     - "--platform=linux/amd64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The `upctl` container image now includes [jq](https://stedolan.github.io/jq/) tool for parsing values from JSON output.
+
 ### Changed
 - Completions will now only suggest private networks as arguments because names or UUIDs of public or utility networks are often not valid arguments.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN make build-dockerised
 
 FROM alpine:3.16
 
-RUN apk add --update --no-cache ca-certificates
+RUN apk add --update --no-cache ca-certificates jq
 COPY --from=build /go/upctl/bin/*dockerised-linux-amd64 /bin/upctl
 
 ENTRYPOINT ["/bin/upctl"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,6 @@
 FROM alpine:3.16
 
-RUN apk add --update --no-cache ca-certificates
+RUN apk add --update --no-cache ca-certificates jq
 COPY upctl /bin/upctl
 
 ENTRYPOINT ["/bin/upctl"]


### PR DESCRIPTION
In scripts, we recommend using `jq` for parsing values from JSON output, instead of grepping human output.