### PR TITLE
 fix: use plurals in base command help messages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Add `ip` and `net` as aliases to `ip-address` and `network` commands, respectively.
 
 ## [2.6.0] - 2023-03-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ Usage:
 upctl [command]
 
 Available Commands:
-account      Manage account
-completion   Generates shell completion
+account      Manage accounts
+completion   Generate the autocompletion script for the specified shell
 database     Manage databases
 help         Help about any command
-ip-address   Manage ip address
-kubernetes   Manage Kubernetes clusters
+ip-address   Manage IP addresses
+kubernetes   Manage Kubernetes clusters (EXPERIMENTAL)
 loadbalancer Manage load balancers
-network      Manage network
-router       Manage router
+network      Manage networks
+router       Manage routers
 server       Manage servers
 storage      Manage storages
 version      Display software information

--- a/internal/commands/account/account.go
+++ b/internal/commands/account/account.go
@@ -6,7 +6,7 @@ import (
 
 // BaseAccountCommand creates the base 'account' command
 func BaseAccountCommand() commands.Command {
-	return &accountCommand{commands.New("account", "Manage account")}
+	return &accountCommand{commands.New("account", "Manage accounts")}
 }
 
 type accountCommand struct {

--- a/internal/commands/ipaddress/ip_address.go
+++ b/internal/commands/ipaddress/ip_address.go
@@ -13,12 +13,17 @@ const maxIPAddressActions = 10
 // BaseIPAddressCommand creates the base 'ip-address' command
 func BaseIPAddressCommand() commands.Command {
 	return &ipAddressCommand{
-		commands.New("ip-address", "Manage ip address"),
+		commands.New("ip-address", "Manage IP addresses"),
 	}
 }
 
 type ipAddressCommand struct {
 	*commands.BaseCommand
+}
+
+// InitCommand implements Command.InitCommand
+func (k *ipAddressCommand) InitCommand() {
+	k.Cobra().Aliases = []string{"ip"}
 }
 
 // GetFamily returns a human-readable string (`"IPv4"` or `"IPv6"`) of the address family of the ip parsed from the string

--- a/internal/commands/ipaddress/ip_address.go
+++ b/internal/commands/ipaddress/ip_address.go
@@ -22,8 +22,8 @@ type ipAddressCommand struct {
 }
 
 // InitCommand implements Command.InitCommand
-func (k *ipAddressCommand) InitCommand() {
-	k.Cobra().Aliases = []string{"ip"}
+func (i *ipAddressCommand) InitCommand() {
+	i.Cobra().Aliases = []string{"ip"}
 }
 
 // GetFamily returns a human-readable string (`"IPv4"` or `"IPv6"`) of the address family of the ip parsed from the string

--- a/internal/commands/network/network.go
+++ b/internal/commands/network/network.go
@@ -25,8 +25,8 @@ type networkCommand struct {
 }
 
 // InitCommand implements Command.InitCommand
-func (k *networkCommand) InitCommand() {
-	k.Cobra().Aliases = []string{"net"}
+func (n *networkCommand) InitCommand() {
+	n.Cobra().Aliases = []string{"net"}
 }
 
 // TODO: figure out a nicer way to do this..

--- a/internal/commands/network/network.go
+++ b/internal/commands/network/network.go
@@ -15,13 +15,18 @@ const maxNetworkActions = 10
 // BaseNetworkCommand creates the base "network" command
 func BaseNetworkCommand() commands.Command {
 	return &networkCommand{
-		BaseCommand: commands.New("network", "Manage network"),
+		BaseCommand: commands.New("network", "Manage networks"),
 	}
 }
 
 type networkCommand struct {
 	*commands.BaseCommand
 	resolver.CachingNetwork
+}
+
+// InitCommand implements Command.InitCommand
+func (k *networkCommand) InitCommand() {
+	k.Cobra().Aliases = []string{"net"}
 }
 
 // TODO: figure out a nicer way to do this..

--- a/internal/commands/router/router.go
+++ b/internal/commands/router/router.go
@@ -9,7 +9,7 @@ const maxRouterActions = 10
 // BaseRouterCommand creates the base "router" command
 func BaseRouterCommand() commands.Command {
 	return &routerCommand{
-		commands.New("router", "Manage router"),
+		commands.New("router", "Manage routers"),
 	}
 }
 

--- a/internal/commands/storage/import_test.go
+++ b/internal/commands/storage/import_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestReaderCounterInterface(t *testing.T) {
+func TestReaderCounterInterface(_ *testing.T) {
 	rc := &readerCounter{}
 	var _ io.Reader = rc
 }

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -1,4 +1,4 @@
-//nolint:nilnil // Here nil, nil returns are used in not-implemented methods required to satisfy an interface
+//nolint:nilnil,revive // Here nil, nil returns and unused parameters are used in not-implemented methods required to satisfy an interface and it does not make sense to rename them when copying functions from our SDK
 package mock
 
 import (


### PR DESCRIPTION
Also adds `ip` and `net` as aliases to `ip-address` and `network` commands, respectively.