### PR TITLE
feat(kubernetes): add support for plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ip` and `net` as aliases to `ip-address` and `network` commands, respectively.
 - Add _Labels_ table to `loadbalancer show`, `network show`, `router show`, `server show`, and `storage show` outputs.
 - Add `kubernetes plans` command for listing available plans.
+- Add `--plan` argument to `kubernetes create` command for selecting cluster plan.
 
 ## [2.6.0] - 2023-03-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `ip` and `net` as aliases to `ip-address` and `network` commands, respectively.
 - Add _Labels_ table to `loadbalancer show`, `network show`, `router show`, `server show`, and `storage show` outputs.
+- Add `kubernetes plans` command for listing available plans.
 
 ## [2.6.0] - 2023-03-14
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/UpCloudLtd/progress v1.0.1
-	github.com/UpCloudLtd/upcloud-go-api/v6 v6.0.0
+	github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.1-0.20230418185030-23e162ba5f2b
 	github.com/adrg/xdg v0.3.2
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/gemalto/flume v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/UpCloudLtd/progress v1.0.1
-	github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.1-0.20230418185030-23e162ba5f2b
+	github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.1
 	github.com/adrg/xdg v0.3.2
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/gemalto/flume v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/UpCloudLtd/progress v1.0.1 h1:e0ptyD2oOGa3udRcLzgRemIN9enGx4Bc9GQ0sZ/1/EY=
 github.com/UpCloudLtd/progress v1.0.1/go.mod h1:hKsRsvlCffcYt/s0krpWvOFozOjpfUYjSkL6CzZztoI=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.1-0.20230418185030-23e162ba5f2b h1:+6xH+JPwgZ0wdiC6wsH7iJx/MA75/BArVWhw7SBpr5s=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.1-0.20230418185030-23e162ba5f2b/go.mod h1:9y8kZ4o4jCagqLfexcnITY8uc/g4+uc18wbnMsDbQJI=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.1 h1:ygO63dDQ5XVqZos91H7qZLHOuV2x2c/YxELQVFxE5sw=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.1/go.mod h1:9y8kZ4o4jCagqLfexcnITY8uc/g4+uc18wbnMsDbQJI=
 github.com/adrg/xdg v0.3.2 h1:GUSGQ5pHdev83AYhDSS1A/CX+0JIsxbiWtow2DSA+RU=
 github.com/adrg/xdg v0.3.2/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/UpCloudLtd/progress v1.0.1 h1:e0ptyD2oOGa3udRcLzgRemIN9enGx4Bc9GQ0sZ/1/EY=
 github.com/UpCloudLtd/progress v1.0.1/go.mod h1:hKsRsvlCffcYt/s0krpWvOFozOjpfUYjSkL6CzZztoI=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.0.0 h1:q4FYAC9/4hmkTop30XMOBMQfgj5iakTQEFEgc3T6dqE=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.0.0/go.mod h1:9y8kZ4o4jCagqLfexcnITY8uc/g4+uc18wbnMsDbQJI=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.1-0.20230418185030-23e162ba5f2b h1:+6xH+JPwgZ0wdiC6wsH7iJx/MA75/BArVWhw7SBpr5s=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.1-0.20230418185030-23e162ba5f2b/go.mod h1:9y8kZ4o4jCagqLfexcnITY8uc/g4+uc18wbnMsDbQJI=
 github.com/adrg/xdg v0.3.2 h1:GUSGQ5pHdev83AYhDSS1A/CX+0JIsxbiWtow2DSA+RU=
 github.com/adrg/xdg v0.3.2/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -149,6 +149,7 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	commands.BuildCommand(kubernetes.ListCommand(), kubernetesCommand.Cobra(), conf)
 	commands.BuildCommand(kubernetes.ShowCommand(), kubernetesCommand.Cobra(), conf)
 	commands.BuildCommand(kubernetes.VersionsCommand(), kubernetesCommand.Cobra(), conf)
+	commands.BuildCommand(kubernetes.PlansCommand(), kubernetesCommand.Cobra(), conf)
 
 	// Kubernetes nodegroup operations
 	nodeGroupCommand := commands.BuildCommand(nodegroup.BaseNodeGroupCommand(), kubernetesCommand.Cobra(), conf)

--- a/internal/commands/kubernetes/create.go
+++ b/internal/commands/kubernetes/create.go
@@ -28,6 +28,7 @@ func CreateCommand() commands.Command {
 				--zone de-fra1`,
 			`upctl kubernetes create \
 				--name my-cluster \
+				--plan production-small \
 				--network 03e5ca07-f36c-4957-a676-e001e40441eb \
 				--node-group count=4,kubelet-arg="log-flush-frequency=5s",label="owner=devteam",label="env=dev",name=my-node-group,plan=K8S-4xCPU-8GB,ssh-key="ssh-ed25519 AAAAo admin@user.com",ssh-key="/path/to/your/public/ssh/key.pub",storage=01000000-0000-4000-8000-000160010100,taint="env=dev:NoSchedule",taint="env=dev2:NoSchedule" \
 				--zone de-fra1`,
@@ -100,6 +101,7 @@ func (c *createCommand) InitCommand() {
 	c.params = createParams{CreateKubernetesClusterRequest: request.CreateKubernetesClusterRequest{}}
 
 	fs.StringVar(&c.params.Name, "name", "", "Kubernetes cluster name.")
+	fs.StringVar(&c.params.Plan, "plan", "development", "Plan to use for the cluster. Run `upctl kubernetes plans` to list all available plans.")
 	fs.StringVar(&c.params.networkArg, "network", "", "Network to use. The value should be name or UUID of a private network.")
 	fs.StringArrayVar(
 		&c.params.nodeGroups,

--- a/internal/commands/kubernetes/create_test.go
+++ b/internal/commands/kubernetes/create_test.go
@@ -73,8 +73,13 @@ func TestCreateKubernetes(t *testing.T) {
 				},
 			},
 		},
+		Plan: "development",
 		Zone: "de-fra1",
 	}
+
+	prodArg := []string{"--plan", "production-small"}
+	prodPlanRequest := oneNodeGroupRequest
+	prodPlanRequest.Plan = "production-small"
 
 	for _, test := range []struct {
 		name    string
@@ -92,6 +97,12 @@ func TestCreateKubernetes(t *testing.T) {
 			name:    "resolve network from name",
 			args:    oneNodeGroupArgs(network.Name),
 			request: oneNodeGroupRequest,
+			wantErr: false,
+		},
+		{
+			name:    "use productions-small plan",
+			args:    append(oneNodeGroupArgs(network.Name), prodArg...),
+			request: prodPlanRequest,
 			wantErr: false,
 		},
 	} {

--- a/internal/commands/kubernetes/plans.go
+++ b/internal/commands/kubernetes/plans.go
@@ -1,0 +1,48 @@
+package kubernetes
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/request"
+)
+
+// PlansCommand creates the "loadbalancer plans" command
+func PlansCommand() commands.Command {
+	return &plansCommand{
+		BaseCommand: commands.New("plans", "List available cluster plans", "upctl kubernetes plans"),
+	}
+}
+
+type plansCommand struct {
+	*commands.BaseCommand
+}
+
+// Execute implements commands.NoArgumentCommand
+func (s *plansCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
+	svc := exec.All()
+	plans, err := svc.GetKubernetesPlans(exec.Context(), &request.GetKubernetesPlansRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	rows := []output.TableRow{}
+	for _, plan := range plans {
+		rows = append(rows, output.TableRow{
+			plan.Name,
+			plan.ServerNumber,
+			plan.MaxNodes,
+		})
+	}
+
+	return output.MarshaledWithHumanOutput{
+		Value: plans,
+		Output: output.Table{
+			Columns: []output.TableColumn{
+				{Key: "name", Header: "Name"},
+				{Key: "server_number", Header: "Control nodes"},
+				{Key: "max_nodes", Header: "Max worker nodes"},
+			},
+			Rows: rows,
+		},
+	}, nil
+}

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -930,3 +930,11 @@ func (m *Service) DeleteKubernetesNodeGroup(ctx context.Context, r *request.Dele
 	}
 	return nil
 }
+
+func (m *Service) GetKubernetesPlans(ctx context.Context, r *request.GetKubernetesPlansRequest) ([]upcloud.KubernetesPlan, error) {
+	args := m.Called(r)
+	if args[0] == nil {
+		return nil, args.Error(1)
+	}
+	return args[0].([]upcloud.KubernetesPlan), args.Error(1)
+}


### PR DESCRIPTION
- [x] Depends on https://github.com/UpCloudLtd/upcloud-go-api/pull/224
- [x] Use released version of Go SDK
- [x] `k8s plans` to list available plans
- [x] Add `--plan` argument to `k8s create`