### PR TITLE
fix(kubernetes): remove legacy plans and update help text

### DIFF
--- a/internal/commands/kubernetes/create.go
+++ b/internal/commands/kubernetes/create.go
@@ -25,13 +25,13 @@ func CreateCommand() commands.Command {
 			`upctl kubernetes create \
 				--name my-cluster \
 				--network 03e5ca07-f36c-4957-a676-e001e40441eb \
-				--node-group count=2,name=my-minimal-node-group,plan=K8S-2xCPU-4GB, \
+				--node-group count=2,name=my-minimal-node-group,plan=2xCPU-4GB, \
 				--zone de-fra1`,
 			`upctl kubernetes create \
 				--name my-cluster \
 				--plan production-small \
 				--network 03e5ca07-f36c-4957-a676-e001e40441eb \
-				--node-group count=4,kubelet-arg="log-flush-frequency=5s",label="owner=devteam",label="env=dev",name=my-node-group,plan=K8S-4xCPU-8GB,ssh-key="ssh-ed25519 AAAAo admin@user.com",ssh-key="/path/to/your/public/ssh/key.pub",storage=01000000-0000-4000-8000-000160010100,taint="env=dev:NoSchedule",taint="env=dev2:NoSchedule" \
+				--node-group count=4,kubelet-arg="log-flush-frequency=5s",label="owner=devteam",label="env=dev",name=my-node-group,plan=4xCPU-8GB,ssh-key="ssh-ed25519 AAAAo admin@user.com",ssh-key="/path/to/your/public/ssh/key.pub",storage=01000000-0000-4000-8000-000160010100,taint="env=dev:NoSchedule",taint="env=dev2:NoSchedule" \
 				--zone de-fra1`,
 		),
 	}
@@ -116,7 +116,7 @@ func (c *createCommand) InitCommand() {
 			"label=\"owner=devteam\","+
 			"label=\"env=dev\","+
 			"name=my-node-group,"+
-			"plan=K8S-2xCPU-4GB,"+
+			"plan=2xCPU-4GB,"+
 			"ssh-key=\"ssh-ed25519 AAAAo admin@user.com\","+
 			"ssh-key=\"/path/to/your/public/ssh/key.pub\","+
 			"storage=01000000-0000-4000-8000-000160010100,"+

--- a/internal/commands/kubernetes/create_test.go
+++ b/internal/commands/kubernetes/create_test.go
@@ -26,7 +26,7 @@ func TestCreateKubernetes(t *testing.T) {
 		return []string{
 			"--name", "my-cluster",
 			"--network", network,
-			"--node-group", "count=2,kubelet-arg=log-flush-frequency=5s,label=owner=devteam,label=env=dev,name=my-node-group,plan=K8S-2xCPU-4GB,ssh-key=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMWq/xsiYPgA/HLsaWHcjAGnwU+pJy9BUmvIlMBpkdn2 admin@user.com,storage=01000000-0000-4000-8000-000160010100,taint=env=dev:NoSchedule,taint=env=dev2:NoSchedule",
+			"--node-group", "count=2,kubelet-arg=log-flush-frequency=5s,label=owner=devteam,label=env=dev,name=my-node-group,plan=2xCPU-4GB,ssh-key=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMWq/xsiYPgA/HLsaWHcjAGnwU+pJy9BUmvIlMBpkdn2 admin@user.com,storage=01000000-0000-4000-8000-000160010100,taint=env=dev:NoSchedule,taint=env=dev2:NoSchedule",
 			"--zone", "de-fra1",
 		}
 	}
@@ -48,7 +48,7 @@ func TestCreateKubernetes(t *testing.T) {
 					},
 				},
 				Name: "my-node-group",
-				Plan: "K8S-2xCPU-4GB",
+				Plan: "2xCPU-4GB",
 				SSHKeys: []string{
 					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMWq/xsiYPgA/HLsaWHcjAGnwU+pJy9BUmvIlMBpkdn2 admin@user.com",
 				},

--- a/internal/commands/kubernetes/nodegroup/create_test.go
+++ b/internal/commands/kubernetes/nodegroup/create_test.go
@@ -76,7 +76,7 @@ func TestCreateKubernetesNodeGroup(t *testing.T) {
 				"--label=owner=devteam",
 				"--label=env=dev",
 				"--name=my-node-group",
-				"--plan=K8S-2xCPU-4GB",
+				"--plan=2xCPU-4GB",
 				"--ssh-key=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMWq/xsiYPgA/HLsaWHcjAGnwU+pJy9BUmvIlMBpkdn2 admin@user.com",
 				"--storage=01000000-0000-4000-8000-000160010100",
 				"--taint=env=dev:NoSchedule",
@@ -97,7 +97,7 @@ func TestCreateKubernetesNodeGroup(t *testing.T) {
 						},
 					},
 					Name: "my-node-group",
-					Plan: "K8S-2xCPU-4GB",
+					Plan: "2xCPU-4GB",
 					SSHKeys: []string{
 						"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMWq/xsiYPgA/HLsaWHcjAGnwU+pJy9BUmvIlMBpkdn2 admin@user.com",
 					},

--- a/internal/commands/kubernetes/show_test.go
+++ b/internal/commands/kubernetes/show_test.go
@@ -113,7 +113,7 @@ func TestShowCommand(t *testing.T) {
   Node group 1 (upcloud-go-sdk-unit-test):
     Name:         upcloud-go-sdk-unit-test              
     Count:        4                                     
-    Plan:         K8S-2xCPU-4GB                         
+    Plan:         2xCPU-4GB                             
     State:        running                               
     Storage UUID: storage-uuid                          
     Storage name: Test storage                          
@@ -128,7 +128,7 @@ func TestShowCommand(t *testing.T) {
   Node group 2 (upcloud-go-sdk-unit-test-2):
     Name:         upcloud-go-sdk-unit-test-2               
     Count:        8                                        
-    Plan:         K8S-4xCPU-8GB                            
+    Plan:         4xCPU-8GB                                
     State:        pending                                  
     Storage UUID: storage-uuid-2                           
     Storage name: Test storage                             

--- a/internal/commands/kubernetes/show_test.go
+++ b/internal/commands/kubernetes/show_test.go
@@ -35,7 +35,7 @@ func TestShowCommand(t *testing.T) {
 					},
 				},
 				Name:  "upcloud-go-sdk-unit-test",
-				Plan:  "K8S-2xCPU-4GB",
+				Plan:  "2xCPU-4GB",
 				State: upcloud.KubernetesNodeGroupStateRunning,
 				KubeletArgs: []upcloud.KubernetesKubeletArg{
 					{
@@ -75,7 +75,7 @@ func TestShowCommand(t *testing.T) {
 					},
 				},
 				Name:  "upcloud-go-sdk-unit-test-2",
-				Plan:  "K8S-4xCPU-8GB",
+				Plan:  "4xCPU-8GB",
 				State: upcloud.KubernetesNodeGroupStatePending,
 				KubeletArgs: []upcloud.KubernetesKubeletArg{
 					{


### PR DESCRIPTION
Server plans with legacy `K8S-` prefix are not supported anymore. Removed references and updated tests.