### PR TITLE
fix: remove `depguard` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,6 @@ linters:
     - bodyclose
     - containedctx
     - deadcode
-    - depguard
     - dogsled
     - errcheck
     - goconst


### PR DESCRIPTION
The linter now (v2) by default blocks using any non standard library packages. Previously it did nothing as we did not have configuration file for it.