### PR TITLE
Add `go install` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Use "upctl [command] --help" for more information about a command.
 
 ## Installation
 
+Install the latest with Go by running:
+
+```bash
+go install github.com/UpCloudLtd/upcloud-cli/cmd/upctl/v2@latest
+```
+
 To use upctl as a binary, download it from the
 [Releases](https://github.com/UpCloudLtd/upcloud-cli/releases) page. After downloading, verify that the client works.
 


### PR DESCRIPTION
Easy to miss and install an older `v1` (as indexed in [Go pkgs here](https://pkg.go.dev/github.com/UpCloudLtd/upcloud-cli)) version otherwise.