### PR TITLE
chore: use Go 1.20

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,16 +10,16 @@ jobs:
     name: Generate and deploy
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout head
+        uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version-file: 'go.mod'
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      - name: Checkout head
-        uses: actions/checkout@v3
       - name: Generate documentation
         run: make docs
       - name: Store generated MkDocs site

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,3 +16,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.53.2
+          args: --timeout=2m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version-file: 'go.mod'
       - name: Checkout head
         uses: actions/checkout@v3
       - name: Run golangci-lint-action

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,12 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout head
+        uses: actions/checkout@v3
       - name: Setup go
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - name: Checkout head
-        uses: actions/checkout@v3
       - name: Run golangci-lint-action
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version-file: 'go.mod'
       - name: Get tag version
         id: git
         run: echo "::set-output name=tag_version::$(make version)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout head
+        uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
-      - name: Checkout head
-        uses: actions/checkout@v3
+          go-version-file: 'go.mod'
       - name: Run tests
         run: make test
       - name: Test build

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,6 @@ linters:
     - bidichk
     - bodyclose
     - containedctx
-    - deadcode
     - dogsled
     - errcheck
     - goconst
@@ -33,13 +32,11 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - tenv
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - wastedassign
     - whitespace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/upcloud-cli/v2
 
-go 1.18
+go 1.20
 
 require (
 	github.com/UpCloudLtd/progress v1.0.1


### PR DESCRIPTION
- Use Go 1.20
- Read Go version in `setup-go` CI step from `go.mod`
- Remove deprecated linters
- Increase timeout for linter since it seems to hit the default every now and then