### PR TITLE
feat(kubernetes): add `kubernetes nodegroup show` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `kubernetes nodegroup show` for displaying node-group details.
+
+### Changed
+- In human readable output of `kubernetes show` command, show node-groups as table. Node-group datails are available with `kubernetes nodegroup show` command.
+
 ## [2.10.0] - 2023-07-17
 ### Added
 - Add `--disable-utility-network-access` for `kubernetes nodegroup create` command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add `kubernetes nodegroup show` for displaying node-group details.
+- Add `kubernetes nodegroup show` for displaying node-group details. This also adds _Nodes_ table and _Anti-affinity_ field that were not available in previous `kubernetes show` output.
 
 ### Changed
 - In human readable output of `kubernetes show` command, show node-groups as table. Node-group datails are available with `kubernetes nodegroup show` command.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ completion   Generate the autocompletion script for the specified shell
 database     Manage databases
 help         Help about any command
 ip-address   Manage IP addresses
-kubernetes   Manage Kubernetes clusters (EXPERIMENTAL)
+kubernetes   Manage Kubernetes clusters
 loadbalancer Manage load balancers
 network      Manage networks
 router       Manage routers
 server       Manage servers
+servergroup  Manage server groups
 storage      Manage storages
 version      Display software information
 zone         Display zone information

--- a/internal/commands/all/all.go
+++ b/internal/commands/all/all.go
@@ -163,6 +163,7 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	nodeGroupCommand := commands.BuildCommand(nodegroup.BaseNodeGroupCommand(), kubernetesCommand.Cobra(), conf)
 	commands.BuildCommand(nodegroup.CreateCommand(), nodeGroupCommand.Cobra(), conf)
 	commands.BuildCommand(nodegroup.ScaleCommand(), nodeGroupCommand.Cobra(), conf)
+	commands.BuildCommand(nodegroup.ShowCommand(), nodeGroupCommand.Cobra(), conf)
 	commands.BuildCommand(nodegroup.DeleteCommand(), nodeGroupCommand.Cobra(), conf)
 
 	// Server group operations

--- a/internal/commands/kubernetes/kubernetes.go
+++ b/internal/commands/kubernetes/kubernetes.go
@@ -7,7 +7,7 @@ import (
 // BaseKubernetesCommand creates the base "kubernetes" command
 func BaseKubernetesCommand() commands.Command {
 	return &kubernetesCommand{
-		commands.New("kubernetes", "Manage Kubernetes clusters (EXPERIMENTAL)"),
+		commands.New("kubernetes", "Manage Kubernetes clusters"),
 	}
 }
 

--- a/internal/commands/kubernetes/nodegroup/delete.go
+++ b/internal/commands/kubernetes/nodegroup/delete.go
@@ -38,8 +38,8 @@ func (s *deleteCommand) InitCommand() {
 	_ = s.Cobra().MarkFlagRequired("name")
 }
 
-// Execute implements commands.MultipleArgumentCommand
-func (s *deleteCommand) Execute(exec commands.Executor, arg string) (output.Output, error) {
+// ExecuteSingleArgument implements commands.SingleArgumentCommand
+func (s *deleteCommand) ExecuteSingleArgument(exec commands.Executor, arg string) (output.Output, error) {
 	msg := fmt.Sprintf("Deleting node group %s from cluster %v", s.name, arg)
 	exec.PushProgressStarted(msg)
 

--- a/internal/commands/kubernetes/nodegroup/nodegroup.go
+++ b/internal/commands/kubernetes/nodegroup/nodegroup.go
@@ -7,7 +7,7 @@ import (
 // BaseNodeGroupCommand creates the base "kubernetes nodegroups" command
 func BaseNodeGroupCommand() commands.Command {
 	return &nodegroupCommand{
-		commands.New("nodegroup", "Manage cluster node-groups (EXPERIMENTAL)"),
+		commands.New("nodegroup", "Manage cluster node-groups"),
 	}
 }
 

--- a/internal/commands/kubernetes/nodegroup/scale.go
+++ b/internal/commands/kubernetes/nodegroup/scale.go
@@ -41,8 +41,8 @@ func (s *scaleCommand) InitCommand() {
 	_ = s.Cobra().MarkFlagRequired("count")
 }
 
-// Execute implements commands.MultipleArgumentCommand
-func (s *scaleCommand) Execute(exec commands.Executor, arg string) (output.Output, error) {
+// ExecuteSingleArgument implements commands.SingleArgumentCommand
+func (s *scaleCommand) ExecuteSingleArgument(exec commands.Executor, arg string) (output.Output, error) {
 	msg := fmt.Sprintf("Scaling node group %s of cluster %v", s.name, arg)
 	exec.PushProgressStarted(msg)
 

--- a/internal/commands/kubernetes/nodegroup/show.go
+++ b/internal/commands/kubernetes/nodegroup/show.go
@@ -40,8 +40,8 @@ func (s *showCommand) InitCommand() {
 	_ = s.Cobra().MarkFlagRequired("name")
 }
 
-// Execute implements commands.MultipleArgumentCommand
-func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
+// ExecuteSingleArgument implements commands.SingleArgumentCommand
+func (s *showCommand) ExecuteSingleArgument(exec commands.Executor, uuid string) (output.Output, error) {
 	svc := exec.All()
 	nodeGroup, err := svc.GetKubernetesNodeGroup(exec.Context(), &request.GetKubernetesNodeGroupRequest{ClusterUUID: uuid, Name: s.name})
 	if err != nil {

--- a/internal/commands/kubernetes/nodegroup/show.go
+++ b/internal/commands/kubernetes/nodegroup/show.go
@@ -118,7 +118,7 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 					},
 				},
 			},
-			labels.GetLabelsSection(nodeGroup.Labels),
+			labels.GetLabelsSectionWithResourceType(nodeGroup.Labels, "node group"),
 			output.CombinedSection{
 				Key:   "taints",
 				Title: "Taints:",

--- a/internal/commands/kubernetes/nodegroup/show.go
+++ b/internal/commands/kubernetes/nodegroup/show.go
@@ -1,0 +1,151 @@
+package nodegroup
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/format"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/labels"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/ui"
+	"github.com/spf13/pflag"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/request"
+)
+
+// ShowCommand creates the "kubernetes nodegroup show" command
+func ShowCommand() commands.Command {
+	return &showCommand{
+		BaseCommand: commands.New(
+			"show",
+			"Show node group details",
+			"upctl kubernetes nodegroup show 55199a44-4751-4e27-9394-7c7661910be3 --name default",
+		),
+	}
+}
+
+type showCommand struct {
+	*commands.BaseCommand
+	name string
+	resolver.CachingKubernetes
+	completion.Kubernetes
+}
+
+// InitCommand implements Command.InitCommand
+func (s *showCommand) InitCommand() {
+	flagSet := &pflag.FlagSet{}
+	flagSet.StringVar(&s.name, "name", "", "Node group name")
+	s.AddFlags(flagSet)
+
+	_ = s.Cobra().MarkFlagRequired("name")
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
+	svc := exec.All()
+	nodeGroup, err := svc.GetKubernetesNodeGroup(exec.Context(), &request.GetKubernetesNodeGroupRequest{ClusterUUID: uuid, Name: s.name})
+	if err != nil {
+		return nil, err
+	}
+
+	taintColumns := []output.TableColumn{
+		{Key: "key", Header: "Key"},
+		{Key: "value", Header: "Value"},
+		{Key: "effect", Header: "Effect"},
+	}
+
+	taintRows := []output.TableRow{}
+	for _, taint := range nodeGroup.Taints {
+		taintRows = append(taintRows, output.TableRow{
+			taint.Key,
+			taint.Value,
+			taint.Effect,
+		})
+	}
+
+	kubeletArgColumns := taintColumns[0:2]
+
+	kubeletArgRows := []output.TableRow{}
+	for _, kubeletArg := range nodeGroup.KubeletArgs {
+		kubeletArgRows = append(kubeletArgRows, output.TableRow{
+			kubeletArg.Key,
+			kubeletArg.Value,
+		})
+	}
+
+	nodeRows := []output.TableRow{}
+	for _, node := range nodeGroup.Nodes {
+		nodeRows = append(nodeRows, output.TableRow{
+			node.UUID,
+			node.Name,
+			node.State,
+		})
+	}
+
+	nodeColumns := []output.TableColumn{
+		{Key: "uuid", Header: "UUID", Colour: ui.DefaultUUUIDColours},
+		{Key: "name", Header: "Name"},
+		{Key: "state", Header: "State", Format: format.KubernetesNodeState},
+	}
+
+	var storageName string
+	if storage, err := svc.GetStorageDetails(exec.Context(), &request.GetStorageDetailsRequest{UUID: nodeGroup.Storage}); err != nil {
+		storageName = ""
+	} else {
+		storageName = storage.Title
+	}
+
+	// For JSON and YAML output, passthrough API response
+	return output.MarshaledWithHumanOutput{
+		Value: nodeGroup,
+		Output: output.Combined{
+			output.CombinedSection{
+				Contents: output.Details{
+					Sections: []output.DetailSection{
+						{
+							Title: "Overview",
+							Rows: []output.DetailRow{
+								{Title: "Name:", Value: nodeGroup.Name},
+								{Title: "Count:", Value: nodeGroup.Count},
+								{Title: "Plan:", Value: nodeGroup.Plan},
+								{Title: "State:", Value: nodeGroup.State, Format: format.KubernetesNodeGroupState},
+								{Title: "Storage UUID:", Value: nodeGroup.Storage, Colour: ui.DefaultUUUIDColours},
+								{Title: "Storage name:", Value: storageName, Format: format.PossiblyUnknownString},
+								{Title: "Anti-affinity:", Value: nodeGroup.AntiAffinity, Format: format.Boolean},
+								{Title: "Utility network access:", Value: nodeGroup.UtilityNetworkAccess, Format: format.Boolean},
+							},
+						},
+					},
+				},
+			},
+			labels.GetLabelsSection(nodeGroup.Labels),
+			output.CombinedSection{
+				Key:   "taints",
+				Title: "Taints:",
+				Contents: output.Table{
+					Columns:      taintColumns,
+					Rows:         taintRows,
+					EmptyMessage: "No taints defined for this node group.",
+				},
+			},
+			output.CombinedSection{
+				Key:   "kubelet_args",
+				Title: "Kubelet arguments:",
+				Contents: output.Table{
+					Columns:      kubeletArgColumns,
+					Rows:         kubeletArgRows,
+					EmptyMessage: "No kubelet arguments defined for this node group.",
+				},
+			},
+			output.CombinedSection{
+				Key:   "nodes",
+				Title: "Nodes:",
+				Contents: output.Table{
+					Columns:      nodeColumns,
+					Rows:         nodeRows,
+					EmptyMessage: "No nodes found for this node group.",
+				},
+			},
+		},
+	}, nil
+}

--- a/internal/commands/kubernetes/nodegroup/show_test.go
+++ b/internal/commands/kubernetes/nodegroup/show_test.go
@@ -1,0 +1,204 @@
+package nodegroup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/config"
+	smock "github.com/UpCloudLtd/upcloud-cli/v2/internal/mock"
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/mockexecute"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestShowCommand(t *testing.T) {
+	text.DisableColors()
+	smallNodeGroup := upcloud.KubernetesNodeGroupDetails{
+		KubernetesNodeGroup: upcloud.KubernetesNodeGroup{
+			AntiAffinity: true,
+			Count:        4,
+			Labels: []upcloud.Label{
+				{
+					Key:   "managedBy",
+					Value: "upcloud-go-sdk-unit-test",
+				},
+				{
+					Key:   "another",
+					Value: "label-thing",
+				},
+			},
+			Name:  "small",
+			Plan:  "1xCPU-1GB",
+			State: upcloud.KubernetesNodeGroupStateRunning,
+			KubeletArgs: []upcloud.KubernetesKubeletArg{
+				{
+					Key:   "somekubeletkey",
+					Value: "somekubeletvalue",
+				},
+			},
+			Taints: []upcloud.KubernetesTaint{
+				{
+					Effect: "NoExecute",
+					Key:    "taintkey1",
+					Value:  "taintvalue1",
+				},
+				{
+					Effect: "NoSchedule",
+					Key:    "taintkey2",
+					Value:  "taintvalue2",
+				},
+			},
+			Storage:              "storage-uuid",
+			SSHKeys:              []string{"somekey"},
+			UtilityNetworkAccess: true,
+		},
+		Nodes: []upcloud.KubernetesNode{
+			{
+				UUID:  "00b1fc81-d471-4ae0-90ea-bfef9dd326bf",
+				Name:  "small-9zhrq",
+				State: upcloud.KubernetesNodeStateRunning,
+			},
+			{
+				UUID:  "009fc510-f65a-4c3f-9917-d7cf0bb3f15f",
+				Name:  "small-nbqvp",
+				State: upcloud.KubernetesNodeStateRunning,
+			},
+			{
+				UUID:  "0039e13a-76a6-4253-90d9-54be10539016",
+				Name:  "small-wzdxz",
+				State: upcloud.KubernetesNodeStateRunning,
+			},
+			{
+				UUID:  "00141c93-afee-4c43-be28-79792675eec2",
+				Name:  "small-xnzvc",
+				State: upcloud.KubernetesNodeStateRunning,
+			},
+		},
+	}
+
+	smallExpected := `  
+  Overview
+    Name:                   small        
+    Count:                  4            
+    Plan:                   1xCPU-1GB    
+    State:                  running      
+    Storage UUID:           storage-uuid 
+    Storage name:           Test storage 
+    Anti-affinity:          yes          
+    Utility network access: yes          
+
+  Labels:
+
+     Key         Value                    
+    ─────────── ──────────────────────────
+     managedBy   upcloud-go-sdk-unit-test 
+     another     label-thing              
+    
+  Taints:
+
+     Key         Value         Effect     
+    ─────────── ───────────── ────────────
+     taintkey1   taintvalue1   NoExecute  
+     taintkey2   taintvalue2   NoSchedule 
+    
+  Kubelet arguments:
+
+     Key              Value            
+    ──────────────── ──────────────────
+     somekubeletkey   somekubeletvalue 
+    
+  Nodes:
+
+     UUID                                   Name          State   
+    ────────────────────────────────────── ───────────── ─────────
+     00b1fc81-d471-4ae0-90ea-bfef9dd326bf   small-9zhrq   running 
+     009fc510-f65a-4c3f-9917-d7cf0bb3f15f   small-nbqvp   running 
+     0039e13a-76a6-4253-90d9-54be10539016   small-wzdxz   running 
+     00141c93-afee-4c43-be28-79792675eec2   small-xnzvc   running 
+    
+`
+
+	emptyNodeGroup := upcloud.KubernetesNodeGroupDetails{
+		KubernetesNodeGroup: upcloud.KubernetesNodeGroup{
+			AntiAffinity:         false,
+			Count:                0,
+			Name:                 "empty",
+			Plan:                 "1xCPU-1GB",
+			State:                upcloud.KubernetesNodeGroupStateRunning,
+			Storage:              "storage-uuid",
+			UtilityNetworkAccess: true,
+		},
+	}
+
+	emptyExpected := `  
+  Overview
+    Name:                   empty        
+    Count:                  0            
+    Plan:                   1xCPU-1GB    
+    State:                  running      
+    Storage UUID:           storage-uuid 
+    Storage name:           Test storage 
+    Anti-affinity:          no           
+    Utility network access: yes          
+
+  Labels:
+
+    No labels defined for this node group.
+    
+  Taints:
+
+    No taints defined for this node group.
+    
+  Kubelet arguments:
+
+    No kubelet arguments defined for this node group.
+    
+  Nodes:
+
+    No nodes found for this node group.
+    
+`
+
+	for _, test := range []struct {
+		name      string
+		nodeGroup *upcloud.KubernetesNodeGroupDetails
+		expected  string
+	}{
+		{
+			name:      "data in all tables",
+			nodeGroup: &smallNodeGroup,
+			expected:  smallExpected,
+		},
+		{
+			name:      "empty states",
+			nodeGroup: &emptyNodeGroup,
+			expected:  emptyExpected,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mService := smock.Service{}
+			mService.On("GetKubernetesClusters", mock.Anything).Return([]upcloud.KubernetesCluster{{Name: "mock-cluster", UUID: "fake-uuid"}}, nil)
+			mService.On("GetKubernetesNodeGroup", mock.Anything).Return(test.nodeGroup, nil)
+			mService.On("GetStorageDetails", mock.Anything).Return(&upcloud.StorageDetails{Storage: upcloud.Storage{Title: "Test storage"}}, nil)
+
+			conf := config.New()
+			command := commands.BuildCommand(ShowCommand(), nil, conf)
+
+			// get resolver to initialize command cache
+			_, err := command.(*showCommand).Get(context.TODO(), &mService)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			command.Cobra().SetArgs([]string{"cluster-name", "--name", test.nodeGroup.Name})
+			output, err := mockexecute.MockExecute(command, &mService, conf)
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, output)
+		})
+	}
+}

--- a/internal/commands/kubernetes/show_test.go
+++ b/internal/commands/kubernetes/show_test.go
@@ -112,36 +112,13 @@ func TestShowCommand(t *testing.T) {
     Zone:                de-fra1                              
     Operational state:   running                              
 
-  
-  Node group 1 (upcloud-go-sdk-unit-test):
-    Name:                   upcloud-go-sdk-unit-test              
-    Count:                  4                                     
-    Plan:                   2xCPU-4GB                             
-    State:                  running                               
-    Storage UUID:           storage-uuid                          
-    Storage name:           Test storage                          
-    Kubelet args:           somekubeletkey=somekubeletvalue       
-    Labels:                 managedBy=upcloud-go-sdk-unit-test    
-                            another=label-thing                   
-    Taints:                 sometaintkey=sometaintvalue:NoExecute 
-                            sometaintkey=sometaintvalue:NoExecute 
-                            sometaintkey=sometaintvalue:NoExecute 
-    Utility network access: yes                                   
+  Node groups:
 
-  
-  Node group 2 (upcloud-go-sdk-unit-test-2):
-    Name:                   upcloud-go-sdk-unit-test-2               
-    Count:                  8                                        
-    Plan:                   4xCPU-8GB                                
-    State:                  pending                                  
-    Storage UUID:           storage-uuid-2                           
-    Storage name:           Test storage                             
-    Kubelet args:           somekubeletkey2=somekubeletvalue2        
-    Labels:                 managedBy=upcloud-go-sdk-unit-test-2     
-                            another2=label-thing-2                   
-    Taints:                 sometaintkey2=sometaintvalue2:NoSchedule 
-    Utility network access: no                                       
-
+     Name                         Count   Plan        Anti affinity   Utility network access   State   
+    ──────────────────────────── ─────── ─────────── ─────────────── ──────────────────────── ─────────
+     upcloud-go-sdk-unit-test         4   2xCPU-4GB   no              yes                      running 
+     upcloud-go-sdk-unit-test-2       8   4xCPU-8GB   no              no                       pending 
+    
 `
 
 	mService := smock.Service{}

--- a/internal/format/kubernetes.go
+++ b/internal/format/kubernetes.go
@@ -33,6 +33,18 @@ func kubernetesNodeGroupStateColour(state upcloud.KubernetesNodeGroupState) text
 	}
 }
 
+// kubernetesNodeStateColour maps kubernetes node states to colours
+func kubernetesNodeStateColour(state upcloud.KubernetesNodeState) text.Colors {
+	switch state {
+	case upcloud.KubernetesNodeStateRunning:
+		return text.Colors{text.FgGreen}
+	case upcloud.KubernetesNodeStatePending:
+		return text.Colors{text.FgYellow}
+	default:
+		return text.Colors{text.FgHiBlack}
+	}
+}
+
 // KubernetesClusterState implements Format function for Kubernetes cluster states
 func KubernetesClusterState(val interface{}) (text.Colors, string, error) {
 	return usingColorFunction(kubernetesClusterStateColour, val)
@@ -41,4 +53,9 @@ func KubernetesClusterState(val interface{}) (text.Colors, string, error) {
 // KubernetesNodeGroupState implements Format function for Kubernetes node-group states
 func KubernetesNodeGroupState(val interface{}) (text.Colors, string, error) {
 	return usingColorFunction(kubernetesNodeGroupStateColour, val)
+}
+
+// KubernetesNodeState implements Format function for Kubernetes node states
+func KubernetesNodeState(val interface{}) (text.Colors, string, error) {
+	return usingColorFunction(kubernetesNodeStateColour, val)
 }

--- a/internal/labels/output.go
+++ b/internal/labels/output.go
@@ -1,12 +1,14 @@
 package labels
 
 import (
+	"fmt"
+
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
 )
 
-// GetLabelsSection returns labels table as output.CombinedSection
-func GetLabelsSection(labels []upcloud.Label) output.CombinedSection {
+// GetLabelsSectionWithResourceType returns labels table as output.CombinedSection with resource type in the empty message.
+func GetLabelsSectionWithResourceType(labels []upcloud.Label, resourceType string) output.CombinedSection {
 	var rows []output.TableRow
 	for _, i := range labels {
 		rows = append(rows, output.TableRow{i.Key, i.Value})
@@ -21,7 +23,12 @@ func GetLabelsSection(labels []upcloud.Label) output.CombinedSection {
 				{Key: "value", Header: "Value"},
 			},
 			Rows:         rows,
-			EmptyMessage: "No labels defined for this resource.",
+			EmptyMessage: fmt.Sprintf("No labels defined for this %s.", resourceType),
 		},
 	}
+}
+
+// GetLabelsSection returns labels table as output.CombinedSection
+func GetLabelsSection(labels []upcloud.Label) output.CombinedSection {
+	return GetLabelsSectionWithResourceType(labels, "resource")
 }

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -936,7 +936,11 @@ func (m *Service) GetKubernetesNodeGroups(ctx context.Context, r *request.GetKub
 }
 
 func (m *Service) GetKubernetesNodeGroup(ctx context.Context, r *request.GetKubernetesNodeGroupRequest) (*upcloud.KubernetesNodeGroupDetails, error) {
-	return nil, nil
+	args := m.Called(r)
+	if args[0] == nil {
+		return nil, args.Error(1)
+	}
+	return args[0].(*upcloud.KubernetesNodeGroupDetails), args.Error(1)
 }
 
 func (m *Service) CreateKubernetesNodeGroup(ctx context.Context, r *request.CreateKubernetesNodeGroupRequest) (*upcloud.KubernetesNodeGroup, error) {


### PR DESCRIPTION
- Add `kubernetes nodegroup show` to display node-group details in tables. This also adds _Nodes_ table and _Anti-affinity_ field to human output.
- Show summary of cluster node-groups as table in `kubernetes show` output.
- Only accept single cluster as positional argument for node-group operations.
- Remove `(EXPERIMENTAL)` notices from kubernetes commands.
