### PR TITLE
fix: print cleaner error message if authentication failed

### DIFF
--- a/internal/clierrors/client_error.go
+++ b/internal/clierrors/client_error.go
@@ -3,6 +3,8 @@ package clierrors
 const (
 	UnspecifiedErrorCode int = 100
 	InterruptSignalCode  int = 101
+	MissingCredentials   int = 102
+	InvalidCredentials   int = 103
 )
 
 // ClientError declares interface for errors known to the client that set specific error code.

--- a/internal/clierrors/command_failed.go
+++ b/internal/clierrors/command_failed.go
@@ -6,6 +6,8 @@ type CommandFailedError struct {
 	FailedCount int
 }
 
+var _ ClientError = CommandFailedError{}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/internal/clierrors/invalid_credentials.go
+++ b/internal/clierrors/invalid_credentials.go
@@ -1,0 +1,32 @@
+package clierrors
+
+import (
+	"errors"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud"
+)
+
+var _ ClientError = InvalidCredentialsError{}
+
+type InvalidCredentialsError struct{}
+
+func (err InvalidCredentialsError) ErrorCode() int {
+	return InvalidCredentials
+}
+
+func (err InvalidCredentialsError) Error() string {
+	return "invalid user credentials, authentication failed using the given username and password"
+}
+
+func CheckAuthenticationFailed(err error) bool {
+	prob := &upcloud.Problem{}
+
+	if errors.As(err, &prob) {
+		errCode := prob.ErrorCode()
+		if errCode == upcloud.ErrCodeAuthenticationFailed || errCode == "INVALID_CREDENTIALS" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/clierrors/missing_credentials.go
+++ b/internal/clierrors/missing_credentials.go
@@ -1,0 +1,17 @@
+package clierrors
+
+import "fmt"
+
+var _ ClientError = MissingCredentialsError{}
+
+type MissingCredentialsError struct {
+	ConfigFile string
+}
+
+func (err MissingCredentialsError) ErrorCode() int {
+	return MissingCredentials
+}
+
+func (err MissingCredentialsError) Error() string {
+	return fmt.Sprintf("user credentials not found, these must be set in config file (%s) or via environment variables", err.ConfigFile)
+}

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -115,8 +115,7 @@ func BuildCommand(child Command, parent *cobra.Command, config *config.Config) C
 		if err != nil {
 			// Error was caused by missing credentials, not incorrect command
 			child.Cobra().SilenceUsage = true
-
-			return fmt.Errorf("cannot create service: %w", err)
+			return err
 		}
 		return commandRunE(child, service, config, args)
 	}

--- a/internal/commands/runcommand.go
+++ b/internal/commands/runcommand.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/clierrors"
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/config"
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/v2/internal/resolver"
@@ -92,6 +93,10 @@ func resolveArguments(nc Command, exec Executor, args []string) (out []resolvedA
 func execute(command Command, executor Executor, args []string, parallelRuns int, executeCommand func(exec Executor, arg string) (output.Output, error)) ([]output.Output, error) {
 	resolvedArgs, err := resolveArguments(command, executor, args)
 	if err != nil {
+		// If authentication failed, return helpful message instead of the raw error.
+		if clierrors.CheckAuthenticationFailed(err) {
+			return nil, clierrors.InvalidCredentialsError{}
+		}
 		return nil, fmt.Errorf("cannot resolve command line arguments: %w", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/UpCloudLtd/upcloud-cli/v2/internal/clierrors"
 	internal "github.com/UpCloudLtd/upcloud-cli/v2/internal/service"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v6/upcloud/client"
@@ -188,14 +189,13 @@ func (s *Config) CreateService() (internal.AllServices, error) {
 	password := s.GetString("password")
 
 	if username == "" || password == "" {
-		// nb. this might give silghtly unexpected results on OS X, as xdg.ConfigHome points to ~/Library/Application Support
+		// This might give silghtly unexpected results on OS X, as xdg.ConfigHome points to ~/Library/Application Support
 		// while we really use/prefer/document ~/.config - which does work on osx as well but won't be displayed here.
-		// TODO: fix this?
 		configDetails := fmt.Sprintf("default location %s", filepath.Join(xdg.ConfigHome, "upctl.yaml"))
 		if s.GetString("config") != "" {
 			configDetails = fmt.Sprintf("used %s", s.GetString("config"))
 		}
-		return nil, fmt.Errorf("user credentials not found, these must be set in config file (%s) or via environment variables", configDetails)
+		return nil, clierrors.MissingCredentialsError{ConfigFile: configDetails}
 	}
 
 	client := client.New(username, password, client.WithTimeout(s.ClientTimeout()))


### PR DESCRIPTION
Missing credentials

```
$ upctl server show asd
Error: user credentials not found, these must be set in config file (used /Users/kangasta/.config/upctl.yaml) or via environment variables
$ echo $?
102
```

Invalid credentials

```
$ upctl server show asd
Error: invalid user credentials, authentication failed using the given username and password
$ echo $?
103
```