### PR TITLE
feat(storage): add encryption support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for storage encryption to storage `create`, `clone`, `show`, and `list` commands as well as server `create` and `show` commands.
+
+### Removed
+
+- From human output of `storage list`, _Created_ column. This field is still available in the machine readable outputs.
+
 ## [3.2.2] - 2024-01-02
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/UpCloudLtd/progress v1.0.2
-	github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.1-0.20240119153151-238b0405abe9
+	github.com/UpCloudLtd/upcloud-go-api/v6 v6.12.0
 	github.com/adrg/xdg v0.3.2
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/gemalto/flume v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/UpCloudLtd/progress v1.0.2
-	github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.0
+	github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.1-0.20240119153151-238b0405abe9
 	github.com/adrg/xdg v0.3.2
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/gemalto/flume v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/UpCloudLtd/progress v1.0.2 h1:CTr1bBuFuXop9TEhR1PakbUMPTlUVL7Bgae9Jgq
 github.com/UpCloudLtd/progress v1.0.2/go.mod h1:iGxOnb9HvHW0yrLGUjHr0lxHhn7TehgWwh7a8NqK6iQ=
 github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.0 h1:8KvsimMoPPBx8IVebtHJHavrJPoJfNL5jsyW4TAC5m4=
 github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.0/go.mod h1:I8rWmBBl+OhiY3AGzKbrobiE5TsLCLNYkCQxE4eJcTg=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.1-0.20240119153151-238b0405abe9 h1:8RSJih/kFj/g+TI0Jvbr//nsf4WdszHXMlM8869yw30=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.1-0.20240119153151-238b0405abe9/go.mod h1:I8rWmBBl+OhiY3AGzKbrobiE5TsLCLNYkCQxE4eJcTg=
 github.com/adrg/xdg v0.3.2 h1:GUSGQ5pHdev83AYhDSS1A/CX+0JIsxbiWtow2DSA+RU=
 github.com/adrg/xdg v0.3.2/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/UpCloudLtd/progress v1.0.2 h1:CTr1bBuFuXop9TEhR1PakbUMPTlUVL7Bgae9JgqXwPg=
 github.com/UpCloudLtd/progress v1.0.2/go.mod h1:iGxOnb9HvHW0yrLGUjHr0lxHhn7TehgWwh7a8NqK6iQ=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.0 h1:8KvsimMoPPBx8IVebtHJHavrJPoJfNL5jsyW4TAC5m4=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.0/go.mod h1:I8rWmBBl+OhiY3AGzKbrobiE5TsLCLNYkCQxE4eJcTg=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.1-0.20240119153151-238b0405abe9 h1:8RSJih/kFj/g+TI0Jvbr//nsf4WdszHXMlM8869yw30=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.11.1-0.20240119153151-238b0405abe9/go.mod h1:I8rWmBBl+OhiY3AGzKbrobiE5TsLCLNYkCQxE4eJcTg=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.12.0 h1:Qol8WuStmqWTXO8Hfel6FjCgLOZ98MGVCvg3ExcEs68=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.12.0/go.mod h1:I8rWmBBl+OhiY3AGzKbrobiE5TsLCLNYkCQxE4eJcTg=
 github.com/adrg/xdg v0.3.2 h1:GUSGQ5pHdev83AYhDSS1A/CX+0JIsxbiWtow2DSA+RU=
 github.com/adrg/xdg v0.3.2/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/commands/server/create_test.go
+++ b/internal/commands/server/create_test.go
@@ -266,8 +266,9 @@ func TestCreateServer(t *testing.T) {
 				"--hostname", "example.com",
 				"--title", "test-server",
 				"--zone", "uk-lon1",
+				"--os-storage-encrypt",
 				"--password-delivery", "email",
-				"--storage", "action=create,address=virtio,type=disk,size=20,title=new-storage",
+				"--storage", "action=create,address=virtio,encrypt=true,type=disk,size=20,title=new-storage",
 				"--storage", fmt.Sprintf("action=clone,storage=%s,title=three-clone", Storage3.Title),
 				"--storage", fmt.Sprintf("action=attach,storage=%s,type=cdrom", Storage1.Title),
 			},
@@ -282,20 +283,22 @@ func TestCreateServer(t *testing.T) {
 				LoginUser:        &request.LoginUser{CreatePassword: "yes"},
 				StorageDevices: request.CreateServerStorageDeviceSlice{
 					request.CreateServerStorageDevice{
-						Action:  "clone",
-						Address: "virtio",
-						Storage: StorageDef.UUID,
-						Title:   "example.com-OS",
-						Size:    50,
-						Tier:    upcloud.StorageTierMaxIOPS,
-						Type:    upcloud.StorageTypeDisk,
+						Action:    "clone",
+						Address:   "virtio",
+						Encrypted: upcloud.FromBool(true),
+						Storage:   StorageDef.UUID,
+						Title:     "example.com-OS",
+						Size:      50,
+						Tier:      upcloud.StorageTierMaxIOPS,
+						Type:      upcloud.StorageTypeDisk,
 					},
 					request.CreateServerStorageDevice{
-						Action:  "create",
-						Address: "virtio",
-						Title:   "new-storage",
-						Size:    20,
-						Type:    upcloud.StorageTypeDisk,
+						Action:    "create",
+						Address:   "virtio",
+						Encrypted: upcloud.FromBool(true),
+						Title:     "new-storage",
+						Size:      20,
+						Type:      upcloud.StorageTypeDisk,
 					},
 					request.CreateServerStorageDevice{
 						Action:  "clone",
@@ -470,6 +473,7 @@ func TestCreateServer(t *testing.T) {
 					assert.Equal(t, test.error, err.Error())
 				}
 			} else {
+				assert.NoError(t, err)
 				mService.AssertNumberOfCalls(t, "GetStorages", 1)
 				mService.AssertNumberOfCalls(t, "CreateServer", 1)
 			}

--- a/internal/commands/server/show.go
+++ b/internal/commands/server/show.go
@@ -91,6 +91,7 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 			storage.Type,
 			storage.Address,
 			storage.Size,
+			storage.Encrypted,
 			strings.Join(flags, " "),
 		})
 	}
@@ -152,6 +153,7 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 					{Key: "type", Header: "Type"},
 					{Key: "address", Header: "Address"},
 					{Key: "size", Header: "Size (GiB)"},
+					{Key: "encrypted", Header: "Encrypted", Format: format.Boolean},
 					{Key: "flags", Header: "Flags"},
 				},
 				Rows: storageRows,

--- a/internal/commands/server/show_test.go
+++ b/internal/commands/server/show_test.go
@@ -172,9 +172,9 @@ func TestServerHumanOutput(t *testing.T) {
     
   Storage: (Flags: B = bootdisk, P = part of plan)
 
-     UUID                                   Title                             Type   Address    Size (GiB)   Flags 
-    ────────────────────────────────────── ───────────────────────────────── ────── ────────── ──────────── ───────
-     012580a1-32a1-466e-a323-689ca16f2d43   Storage for server1.example.com   disk   virtio:0           20   P     
+     UUID                                   Title                             Type   Address    Size (GiB)   Encrypted   Flags 
+    ────────────────────────────────────── ───────────────────────────────── ────── ────────── ──────────── ─────────── ───────
+     012580a1-32a1-466e-a323-689ca16f2d43   Storage for server1.example.com   disk   virtio:0           20   no          P     
     
   NICs: (Flags: S = source IP filtering, B = bootable)
 

--- a/internal/commands/storage/clone.go
+++ b/internal/commands/storage/clone.go
@@ -54,7 +54,7 @@ func (s *cloneCommand) InitCommand() {
 	flagSet.StringVar(&s.params.Tier, "tier", defaultCloneParams.Tier, "The storage tier to use.")
 	flagSet.StringVar(&s.params.Title, "title", defaultCloneParams.Title, "A short, informational description.")
 	flagSet.StringVar(&s.params.Zone, "zone", defaultCloneParams.Zone, namedargs.ZoneDescription("storage"))
-	config.AddToggleFlag(flagSet, &s.params.encrypted, "encrypted", false, "Encrypt the new storage.")
+	config.AddToggleFlag(flagSet, &s.params.encrypted, "encrypt", false, "Encrypt the new storage.")
 
 	s.AddFlags(flagSet)
 	_ = s.Cobra().MarkFlagRequired("title")

--- a/internal/commands/storage/clone.go
+++ b/internal/commands/storage/clone.go
@@ -24,6 +24,7 @@ type cloneCommand struct {
 
 type cloneParams struct {
 	request.CloneStorageRequest
+	encrypted config.OptionalBoolean
 }
 
 // CloneCommand creates the "storage clone" command
@@ -53,6 +54,7 @@ func (s *cloneCommand) InitCommand() {
 	flagSet.StringVar(&s.params.Tier, "tier", defaultCloneParams.Tier, "The storage tier to use.")
 	flagSet.StringVar(&s.params.Title, "title", defaultCloneParams.Title, "A short, informational description.")
 	flagSet.StringVar(&s.params.Zone, "zone", defaultCloneParams.Zone, namedargs.ZoneDescription("storage"))
+	config.AddToggleFlag(flagSet, &s.params.encrypted, "encrypted", false, "Encrypt the new storage.")
 
 	s.AddFlags(flagSet)
 	_ = s.Cobra().MarkFlagRequired("title")
@@ -68,6 +70,7 @@ func (s *cloneCommand) Execute(exec commands.Executor, uuid string) (output.Outp
 	svc := exec.Storage()
 	req := s.params.CloneStorageRequest
 	req.UUID = uuid
+	req.Encrypted = s.params.encrypted.AsUpcloudBoolean()
 
 	msg := fmt.Sprintf("Cloning storage %v", uuid)
 	exec.PushProgressStarted(msg)

--- a/internal/commands/storage/clone_test.go
+++ b/internal/commands/storage/clone_test.go
@@ -67,6 +67,17 @@ func TestCloneCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "encrypted",
+			args: []string{"--zone", "test-zone", "--title", "test-title", "--encrypt"},
+			expected: request.CloneStorageRequest{
+				Encrypted: upcloud.FromBool(true),
+				UUID:      Storage2.UUID,
+				Zone:      "test-zone",
+				Tier:      "hdd",
+				Title:     "test-title",
+			},
+		},
+		{
 			name: "title is missing",
 			args: []string{
 				"--zone", "zone",

--- a/internal/commands/storage/create.go
+++ b/internal/commands/storage/create.go
@@ -50,6 +50,7 @@ func newCreateParams() createParams {
 type createParams struct {
 	request.CreateStorageRequest
 	backupTime string
+	encrypted  config.OptionalBoolean
 }
 
 func (s *createParams) processParams() error {
@@ -62,6 +63,9 @@ func (s *createParams) processParams() error {
 	} else {
 		s.BackupRule = nil
 	}
+
+	s.Encrypted = s.encrypted.AsUpcloudBoolean()
+
 	return nil
 }
 
@@ -76,6 +80,7 @@ func applyCreateFlags(fs *pflag.FlagSet, dst, def *createParams) {
 	fs.IntVar(&dst.Size, "size", def.Size, "Size of the storage in GiB.")
 	fs.StringVar(&dst.Zone, "zone", def.Zone, namedargs.ZoneDescription("storage"))
 	fs.StringVar(&dst.Tier, "tier", def.Tier, "Storage tier.")
+	config.AddToggleFlag(fs, &dst.encrypted, "encrypted", false, "Encrypt the storage.")
 	fs.StringVar(&dst.backupTime, "backup-time", def.backupTime, "The time when to create a backup in HH:MM. Empty value means no backups.")
 	fs.StringVar(&dst.BackupRule.Interval, "backup-interval", def.BackupRule.Interval, "The interval of the backup.\nAvailable: daily,mon,tue,wed,thu,fri,sat,sun")
 	fs.IntVar(&dst.BackupRule.Retention, "backup-retention", def.BackupRule.Retention, "How long to store the backups in days. The accepted range is 1-1095")

--- a/internal/commands/storage/create.go
+++ b/internal/commands/storage/create.go
@@ -80,7 +80,7 @@ func applyCreateFlags(fs *pflag.FlagSet, dst, def *createParams) {
 	fs.IntVar(&dst.Size, "size", def.Size, "Size of the storage in GiB.")
 	fs.StringVar(&dst.Zone, "zone", def.Zone, namedargs.ZoneDescription("storage"))
 	fs.StringVar(&dst.Tier, "tier", def.Tier, "Storage tier.")
-	config.AddToggleFlag(fs, &dst.encrypted, "encrypted", false, "Encrypt the storage.")
+	config.AddToggleFlag(fs, &dst.encrypted, "encrypt", false, "Encrypt the storage.")
 	fs.StringVar(&dst.backupTime, "backup-time", def.backupTime, "The time when to create a backup in HH:MM. Empty value means no backups.")
 	fs.StringVar(&dst.BackupRule.Interval, "backup-interval", def.BackupRule.Interval, "The interval of the backup.\nAvailable: daily,mon,tue,wed,thu,fri,sat,sun")
 	fs.IntVar(&dst.BackupRule.Retention, "backup-retention", def.BackupRule.Retention, "How long to store the backups in days. The accepted range is 1-1095")

--- a/internal/commands/storage/create_test.go
+++ b/internal/commands/storage/create_test.go
@@ -68,6 +68,7 @@ func TestCreateCommand(t *testing.T) {
 			args: []string{
 				"--title", "create-storage-test",
 				"--zone", "abc",
+				"--encrypt",
 				"--size", "30",
 				"--tier", "xyz",
 				"--backup-time", "09:00",
@@ -75,10 +76,11 @@ func TestCreateCommand(t *testing.T) {
 				"--backup-interval", "mon",
 			},
 			expected: request.CreateStorageRequest{
-				Size:  30,
-				Tier:  "xyz",
-				Title: "create-storage-test",
-				Zone:  "abc",
+				Encrypted: upcloud.FromBool(true),
+				Size:      30,
+				Tier:      "xyz",
+				Title:     "create-storage-test",
+				Zone:      "abc",
 				BackupRule: &upcloud.BackupRule{
 					Interval:  "mon",
 					Time:      "0900",

--- a/internal/commands/storage/list.go
+++ b/internal/commands/storage/list.go
@@ -99,6 +99,7 @@ func (s *listCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Ou
 		rows = append(rows, output.TableRow{
 			storage.UUID,
 			storage.Title,
+			storage.Encrypted,
 			storage.Type,
 			storage.Size,
 			storage.State,
@@ -115,13 +116,13 @@ func (s *listCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Ou
 			Columns: []output.TableColumn{
 				{Key: "uuid", Header: "UUID", Colour: ui.DefaultUUUIDColours},
 				{Key: "title", Header: "Title"},
+				{Key: "encrypted", Header: "Encrypted", Format: format.Boolean},
 				{Key: "type", Header: "Type"},
 				{Key: "size", Header: "Size"},
 				{Key: "state", Header: "State", Format: format.StorageState},
 				{Key: "tier", Header: "Tier"},
 				{Key: "zone", Header: "Zone"},
 				{Key: "access", Header: "Access"},
-				{Key: "created", Header: "Created"},
 			},
 			Rows: rows,
 		},

--- a/internal/commands/storage/list_test.go
+++ b/internal/commands/storage/list_test.go
@@ -25,14 +25,15 @@ func TestListStorages(t *testing.T) {
 		Tier:   "maxiops",
 	}
 	Storage2 := upcloud.Storage{
-		UUID:   UUID2,
-		Title:  Title2,
-		Access: "private",
-		State:  "online",
-		Type:   "normal",
-		Zone:   "fi-hel1",
-		Size:   40,
-		Tier:   "maxiops",
+		UUID:      UUID2,
+		Title:     Title2,
+		Encrypted: upcloud.FromBool(true),
+		Access:    "private",
+		State:     "online",
+		Type:      "normal",
+		Zone:      "fi-hel1",
+		Size:      40,
+		Tier:      "maxiops",
 	}
 	Storage3 := upcloud.Storage{
 		UUID:   UUID3,

--- a/internal/commands/storage/show.go
+++ b/internal/commands/storage/show.go
@@ -61,6 +61,7 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 						{Title: "State:", Key: "state", Value: storage.State, Format: format.StorageState},
 						{Title: "Size:", Key: "size", Value: storage.Size},
 						{Title: "Tier:", Key: "tier", Value: storage.Tier},
+						{Title: "Encrypted:", Key: "encrypted", Value: storage.Encrypted, Format: format.Boolean},
 						{Title: "Zone:", Key: "zone", Value: storage.Zone},
 						{Title: "Server:", Key: "servers", Value: storage.ServerUUIDs, Format: formatShowServers},
 						{Title: "Origin:", Key: "origin", Value: storage.Origin, Colour: ui.DefaultUUUIDColours},

--- a/internal/commands/storage/show_test.go
+++ b/internal/commands/storage/show_test.go
@@ -51,18 +51,19 @@ func TestStorageHumanOutput(t *testing.T) {
 
 	expected := `  
   Storage
-    UUID:    01101f27-196f-47e9-a055-4e2e8bb3b419 
-    Title:   test-1                               
-    Access:  private                              
-    Type:    normal                               
-    State:   online                               
-    Size:    10                                   
-    Tier:    maxiops                              
-    Zone:    fi-hel1                              
-    Server:  0077fa3d-32db-4b09-9f5f-30d9e9afb565 
-    Origin:                                       
-    Created: 0001-01-01 00:00:00 +0000 UTC        
-    Licence: 0                                    
+    UUID:      01101f27-196f-47e9-a055-4e2e8bb3b419 
+    Title:     test-1                               
+    Access:    private                              
+    Type:      normal                               
+    State:     online                               
+    Size:      10                                   
+    Tier:      maxiops                              
+    Encrypted: no                                   
+    Zone:      fi-hel1                              
+    Server:    0077fa3d-32db-4b09-9f5f-30d9e9afb565 
+    Origin:                                         
+    Created:   0001-01-01 00:00:00 +0000 UTC        
+    Licence:   0                                    
 
   Labels:
 
@@ -112,6 +113,7 @@ func TestStorageLabels(t *testing.T) {
 		Size:       10,
 		State:      "online",
 		Tier:       "maxiops",
+		Encrypted:  upcloud.FromBool(true),
 		Title:      "test-1",
 		Type:       "normal",
 		UUID:       "01101f27-196f-47e9-a055-4e2e8bb3b419",
@@ -135,18 +137,19 @@ func TestStorageLabels(t *testing.T) {
 
 	expected := `  
   Storage
-    UUID:    01101f27-196f-47e9-a055-4e2e8bb3b419 
-    Title:   test-1                               
-    Access:  private                              
-    Type:    normal                               
-    State:   online                               
-    Size:    10                                   
-    Tier:    maxiops                              
-    Zone:    fi-hel1                              
-    Server:  0077fa3d-32db-4b09-9f5f-30d9e9afb565 
-    Origin:                                       
-    Created: 0001-01-01 00:00:00 +0000 UTC        
-    Licence: 0                                    
+    UUID:      01101f27-196f-47e9-a055-4e2e8bb3b419 
+    Title:     test-1                               
+    Access:    private                              
+    Type:      normal                               
+    State:     online                               
+    Size:      10                                   
+    Tier:      maxiops                              
+    Encrypted: yes                                  
+    Zone:      fi-hel1                              
+    Server:    0077fa3d-32db-4b09-9f5f-30d9e9afb565 
+    Origin:                                         
+    Created:   0001-01-01 00:00:00 +0000 UTC        
+    Licence:   0                                    
 
   Labels:
 

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -1073,6 +1073,14 @@ func (m *Service) DeleteServerGroup(ctx context.Context, r *request.DeleteServer
 	return nil
 }
 
+func (m *Service) AddServerToServerGroup(ctx context.Context, r *request.AddServerToServerGroupRequest) error {
+	return nil
+}
+
+func (m *Service) RemoveServerFromServerGroup(ctx context.Context, r *request.RemoveServerFromServerGroupRequest) error {
+	return nil
+}
+
 func (m *Service) GetManagedObjectStorageRegions(ctx context.Context, r *request.GetManagedObjectStorageRegionsRequest) ([]upcloud.ManagedObjectStorageRegion, error) {
 	return nil, nil
 }


### PR DESCRIPTION
- [x] Add support to server commands
- [x] Use released version of Go SDK. Depends on https://github.com/UpCloudLtd/upcloud-go-api/pull/287
- [x] Update tests