### PR TITLE
fix(docs): overwrite colors in sidebar title

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -24,3 +24,16 @@
 .md-content table {
     width: 100%;
 }
+
+.md-nav--primary .md-nav__title[for="__drawer"] {
+  background-color: inherit;
+}
+
+.md-nav__title .md-nav__button.md-logo :is(img, svg) {
+  height: 1.4rem;
+  margin: 0.5rem auto;
+}
+
+.md-nav__source {
+  background-color: inherit;
+}

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -27,6 +27,7 @@
 
 .md-nav--primary .md-nav__title[for="__drawer"] {
   background-color: inherit;
+  text-overflow: unset;
 }
 
 .md-nav__title .md-nav__button.md-logo :is(img, svg) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Dependencies for auto-generating and developing docs
-mkdocs~=1.4
-mkdocs-material~=8.5
+mkdocs~=1.5
+mkdocs-material~=9.5
 mkdocs-macros-plugin~=1.0


### PR DESCRIPTION
### Before

![Screen Shot 2024-02-29 at 11 26 21](https://github.com/UpCloudLtd/upcloud-cli/assets/6261016/c8e1725d-f832-4926-a083-c340be307a30)

### After

![Screen Shot 2024-02-29 at 11 26 04](https://github.com/UpCloudLtd/upcloud-cli/assets/6261016/074260ac-796a-4457-9a43-0f8c3ab773e5)
