### PR TITLE
refactor(server): group plans by type in `server plans` human output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+### Added
 
 - Add `gateway plans` command for listing gateway plans.
+
+### Changed
+
+- In all outputs of `server plans`, sort plans by CPU count, memory amount, and storage size.
+- In human readable output of `server plans`, group plans by type.
 
 ## [3.8.1] - 2024-05-24
 

--- a/internal/commands/server/firewall/show_test.go
+++ b/internal/commands/server/firewall/show_test.go
@@ -143,7 +143,8 @@ func TestFirewallShowHumanOutput(t *testing.T) {
 		},
 	}
 
-	expected := `  Firewall rules
+	expected := `
+  Firewall rules
 
      #   Action   Source          Destination   Dir   Proto    
     ─── ──────── ─────────────── ───────────── ───── ──────────

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -75,13 +75,28 @@ func (m Combined) MarshalHuman() ([]byte, error) {
 			marshaled = prefixLines(marshaled, "    ")
 		}
 		out = append(out, marshaled...)
+
+		// ensure newline before first section
+		if i == 0 && firstNonSpaceChar(out) != '\n' {
+			out = append([]byte("\n"), out...)
+		}
+
+		// dont add newline after the last section
 		if i < len(m)-1 {
-			// dont add newline after the last section
 			out = append(out, []byte("\n")...)
 		}
 	}
 
 	return out, nil
+}
+
+func firstNonSpaceChar(bytes []byte) byte {
+	for _, b := range bytes {
+		if b != ' ' {
+			return b
+		}
+	}
+	return 0
 }
 
 func prefixLines(marshaled []byte, s string) (out []byte) {

--- a/internal/output/combined_test.go
+++ b/internal/output/combined_test.go
@@ -69,7 +69,8 @@ func TestCombined(t *testing.T) {
 					},
 				}},
 			},
-			expectedHumanResult: `  MOCK
+			expectedHumanResult: `
+  MOCK
 
      B   D  
     ─── ────


### PR DESCRIPTION
Example output:

```txt
$ upctl server plans

  General purpose

     Name           Cores   Memory   Storage size   Storage tier   Transfer out (GiB/month) 
    ────────────── ─────── ──────── ────────────── ────────────── ──────────────────────────
     1xCPU-1GB          1     1024             25   maxiops                            1024 
     1xCPU-2GB          1     2048             50   maxiops                            2048 
     2xCPU-4GB          2     4096             80   maxiops                            4096 
     4xCPU-8GB          4     8192            160   maxiops                            5120 
     6xCPU-16GB         6    16384            320   maxiops                            6144 
     8xCPU-32GB         8    32768            640   maxiops                            7168 
     12xCPU-48GB       12    49152            960   maxiops                            9216 
     16xCPU-64GB       16    65536           1280   maxiops                           10240 
     24xCPU-96GB       24    98304           1920   maxiops                           12288 
     32xCPU-128GB      32   131072           2048   maxiops                           24576 
     38xCPU-192GB      38   196608           2048   maxiops                           24576 
     48xCPU-256GB      48   262144           2048   maxiops                           24576 
     64xCPU-384GB      64   393216           2048   maxiops                           24576 
    
  High CPU

     Name                 Cores   Memory   Storage size   Storage tier   Transfer out (GiB/month) 
    ──────────────────── ─────── ──────── ────────────── ────────────── ──────────────────────────
     HICPU-8xCPU-12GB         8    12288            100   maxiops                            4096 
     HICPU-8xCPU-16GB         8    16384            200   maxiops                            4096 
     HICPU-16xCPU-24GB       16    24576            100   maxiops                            5120 
     HICPU-16xCPU-32GB       16    32768            200   maxiops                            5120 
     HICPU-32xCPU-48GB       32    49152            200   maxiops                            6144 
     HICPU-32xCPU-64GB       32    65536            300   maxiops                            6144 
     HICPU-64xCPU-96GB       64    98304            200   maxiops                            7168 
     HICPU-64xCPU-128GB      64   131072            300   maxiops                            7168 
    
  High memory

     Name                 Cores   Memory   Storage size   Storage tier   Transfer out (GiB/month) 
    ──────────────────── ─────── ──────── ────────────── ────────────── ──────────────────────────
     HIMEM-2xCPU-8GB          2     8192            100   maxiops                            2048 
     HIMEM-2xCPU-16GB         2    16384            100   maxiops                            2048 
     HIMEM-4xCPU-32GB         4    32768            100   maxiops                            4096 
     HIMEM-4xCPU-64GB         4    65536            200   maxiops                            4096 
     HIMEM-6xCPU-128GB        6   131072            300   maxiops                            6144 
     HIMEM-8xCPU-192GB        8   196608            400   maxiops                            8192 
     HIMEM-12xCPU-256GB      12   262144            500   maxiops                           10240 
     HIMEM-16xCPU-384GB      16   393216            600   maxiops                           12288 
    
  Developer

     Name            Cores   Memory   Storage size   Storage tier   Transfer out (GiB/month) 
    ─────────────── ─────── ──────── ────────────── ────────────── ──────────────────────────
     DEV-1xCPU-1GB       1     1024             20   standard                           1024 
     DEV-1xCPU-2GB       1     2048             30   standard                           2048 
     DEV-1xCPU-4GB       1     4096             40   standard                           3072 
    
```