### PR TITLE
feat(server): take stopped/started state into account in completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Take server state into account in server completions. For example, do not offer started servers as completions for `server start` command.
+
 ## [3.11.1] - 2024-08-12
 
 ### Fixed

--- a/internal/commands/server/delete.go
+++ b/internal/commands/server/delete.go
@@ -29,7 +29,7 @@ func DeleteCommand() commands.Command {
 type deleteCommand struct {
 	*commands.BaseCommand
 	resolver.CachingServer
-	completion.Server
+	completion.StoppedServer
 	deleteStorages config.OptionalBoolean
 }
 

--- a/internal/commands/server/restart.go
+++ b/internal/commands/server/restart.go
@@ -29,7 +29,7 @@ func RestartCommand() commands.Command {
 type restartCommand struct {
 	*commands.BaseCommand
 	resolver.CachingServer
-	completion.Server
+	completion.StartedServer
 	WaitForServerToStart bool
 	StopType             string
 	Host                 int

--- a/internal/commands/server/start.go
+++ b/internal/commands/server/start.go
@@ -27,7 +27,7 @@ func StartCommand() commands.Command {
 
 type startCommand struct {
 	*commands.BaseCommand
-	completion.Server
+	completion.StoppedServer
 	resolver.CachingServer
 	host      int
 	avoidHost int

--- a/internal/commands/server/stop.go
+++ b/internal/commands/server/stop.go
@@ -33,7 +33,7 @@ type stopCommand struct {
 	StopType string
 	wait     config.OptionalBoolean
 	resolver.CachingServer
-	completion.Server
+	completion.StartedServer
 }
 
 // InitCommand implements Command.InitCommand

--- a/internal/completion/server.go
+++ b/internal/completion/server.go
@@ -2,6 +2,7 @@ package completion
 
 import (
 	"context"
+	"slices"
 
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/service"
 	"github.com/spf13/cobra"
@@ -15,13 +16,41 @@ var _ Provider = Server{}
 
 // CompleteArgument implements completion.Provider
 func (s Server) CompleteArgument(ctx context.Context, svc service.AllServices, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return completeServers(ctx, svc, toComplete)
+}
+
+// StartedServer implements argument completion for started servers, by uuid, name or hostname.
+type StartedServer struct{}
+
+// make sure StartedServer implements the interface
+var _ Provider = StartedServer{}
+
+// CompleteArgument implements completion.Provider
+func (s StartedServer) CompleteArgument(ctx context.Context, svc service.AllServices, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return completeServers(ctx, svc, toComplete, "started")
+}
+
+// Stopped implements argument completion for stopped servers, by uuid, name or hostname.
+type StoppedServer struct{}
+
+// make sure StoppedServer implements the interface
+var _ Provider = StoppedServer{}
+
+// CompleteArgument implements completion.Provider
+func (s StoppedServer) CompleteArgument(ctx context.Context, svc service.AllServices, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return completeServers(ctx, svc, toComplete, "stopped")
+}
+
+func completeServers(ctx context.Context, svc service.AllServices, toComplete string, states ...string) ([]string, cobra.ShellCompDirective) {
 	servers, err := svc.GetServers(ctx)
 	if err != nil {
 		return None(toComplete)
 	}
 	var vals []string
 	for _, v := range servers.Servers {
-		vals = append(vals, v.UUID, v.Hostname, v.Title)
+		if len(states) == 0 || slices.Contains(states, v.State) {
+			vals = append(vals, v.UUID, v.Hostname, v.Title)
+		}
 	}
 	return MatchStringPrefix(vals, toComplete, true), cobra.ShellCompDirectiveNoFileComp
 }


### PR DESCRIPTION
We could add some more to avoid various other completions for servers let's say in `maintenance` state, but this covers the most common cases for now.