### PR TITLE
fix(matchers): name matching case-insensitive

### DIFF
--- a/internal/resolver/matchers.go
+++ b/internal/resolver/matchers.go
@@ -1,10 +1,12 @@
 package resolver
 
 import (
+	"strings"
+
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
 )
 
 // MatchStringWithWhitespace checks if arg that may include whitespace matches given value. This checks both quoted args and auto-completed args handled with completion.RemoveWordBreaks.
 func MatchArgWithWhitespace(arg string, value string) bool {
-	return completion.RemoveWordBreaks(value) == arg || value == arg
+	return completion.RemoveWordBreaks(value) == arg || value == arg || strings.EqualFold(arg, value)
 }

--- a/internal/resolver/matchers_test.go
+++ b/internal/resolver/matchers_test.go
@@ -1,0 +1,43 @@
+package resolver
+
+import "testing"
+
+func TestMatchers(t *testing.T) {
+	cases := []struct {
+		name     string
+		execFn   func(string, string) bool
+		arg      string
+		value    string
+		expected bool
+	}{
+		{
+			name:     "Matcher no case",
+			execFn:   MatchArgWithWhitespace,
+			arg:      "test",
+			value:    "test",
+			expected: true,
+		},
+		{
+			name:     "Matcher with case",
+			execFn:   MatchArgWithWhitespace,
+			arg:      "TeSt",
+			value:    "test",
+			expected: true,
+		},
+		{
+			name:     "Matcher invalid",
+			execFn:   MatchArgWithWhitespace,
+			arg:      "test",
+			value:    "invalid",
+			expected: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if result := tt.execFn(tt.arg, tt.value); result != tt.expected {
+				t.Errorf("Matcher() failed %v, wanted %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #102 

Added [strings.EqualFold](https://pkg.go.dev/strings#EqualFold) to `MatchArgWithWhitespace` function name.
Added tests for `matchers.go` file.

```sh
./upctl network list                  

 UUID                                   Name              Router   Type      Zone    
────────────────────────────────────── ───────────────── ──────── ───────── ─────────
 0365d711-ab40-425e-bab3-92a1e351996d   example network            private   de-fra1 
```

```sh
./upctl network show "Example Network"
  
  Common
    UUID:   0365d711-ab40-425e-bab3-92a1e351996d 
    Name:   example network                      
    Router:                                      
    Type:   private                              
    Zone:   de-fra1                              

  Labels:

    No labels defined for this resource.
    
  IP Networks:

     Address       Family   DHCP   DHCP Def Router   DHCP DNS 
    ───────────── ──────── ────── ───────────────── ──────────
     10.0.0.0/24   IPv4     yes    no                         
    
  Servers:

     UUID                                   Title                                       Hostname             State   
    ────────────────────────────────────── ─────────────────────────────────────────── ──────────────────── ─────────
     0088f557-7939-48ec-b589-6138dbd4f084   ubuntu.example.tld (managed by terraform)   ubuntu.example.tld   started 
```