### PR TITLE
docs: enable instant navigation

### DIFF
--- a/mkdocs.base.yaml
+++ b/mkdocs.base.yaml
@@ -26,7 +26,8 @@ theme:
     code: Source Code Pro
   favicon: favicon.png
   language: en
-  features: []
+  features:
+    - navigation.instant
 
 plugins:
   - search


### PR DESCRIPTION
This reduces page jumping and avoids repository details animation when navigating to another page inside the documentation.