### PR TITLE
feat(config): added initial keyring support (#83)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
           go-version-file: 'go.mod'
       - name: Install keyring test dependencies on Ubuntu
         run: |
-          apt-get update
-          apt-get install -y gnome-keyring build-essential ca-certificates
+          sudo apt-get update
+          sudo apt-get install -y gnome-keyring build-essential ca-certificates
         if: matrix.os == 'ubuntu-latest'
       - name: Run tests on Ubuntu with keyring
         run: | 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,20 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
+      - name: Install keyring test dependencies on Ubuntu
+        run: |
+          apt-get update
+          apt-get install -y gnome-keyring build-essential ca-certificates
+        if: matrix.os == 'ubuntu-latest'
+      - name: Run tests on Ubuntu with keyring
+        run: | 
+          echo 'somecredstorepass' | gnome-keyring-daemon --unlock
+          make test
+        shell: dbus-run-session -- bash --noprofile --norc -eo pipefail {0}
+        if: matrix.os == 'ubuntu-latest'
       - name: Run tests
         run: make test
+        if: matrix.os != 'ubuntu-latest'
       - name: Test build
         run: make build
       - name: Test Runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Experimental support for reading password or token from system keyring.
+
 ## [3.15.0] - 2025-02-26
 
 ### Added
@@ -41,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent filename completion of flags that don't take filename args.
 
 ### Deprecated
+
 - Deprecation of some commands and aliases ( new command names added to improve consistency )
     - Deprecated commands: 
         - loadbalancer

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.9.0
+	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/crypto v0.31.0
 	golang.org/x/term v0.27.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -22,10 +23,13 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	github.com/ansel1/merry v1.5.0 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -44,6 +46,8 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -74,6 +78,8 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -105,6 +111,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -273,6 +281,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/internal/clierrors/missing_credentials.go
+++ b/internal/clierrors/missing_credentials.go
@@ -13,5 +13,5 @@ func (err MissingCredentialsError) ErrorCode() int {
 }
 
 func (err MissingCredentialsError) Error() string {
-	return fmt.Sprintf("user credentials not found, these must be set in config file (%s) or via environment variables", err.ConfigFile)
+	return fmt.Sprintf("user credentials not found, these must be set in config file (%s) or via environment variables or in a keyring (upctl)", err.ConfigFile)
 }

--- a/internal/clierrors/missing_credentials.go
+++ b/internal/clierrors/missing_credentials.go
@@ -5,7 +5,8 @@ import "fmt"
 var _ ClientError = MissingCredentialsError{}
 
 type MissingCredentialsError struct {
-	ConfigFile string
+	ConfigFile  string
+	ServiceName string
 }
 
 func (err MissingCredentialsError) ErrorCode() int {
@@ -13,5 +14,5 @@ func (err MissingCredentialsError) ErrorCode() int {
 }
 
 func (err MissingCredentialsError) Error() string {
-	return fmt.Sprintf("user credentials not found, these must be set in config file (%s) or via environment variables or in a keyring (upctl)", err.ConfigFile)
+	return fmt.Sprintf("user credentials not found, these must be set in config file (%s) or via environment variables or in a keyring (%s)", err.ConfigFile, err.ServiceName)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,7 +103,9 @@ func (s *Config) Load() error {
 	if v.GetString("username") != "" && v.GetString("password") == "" {
 		password, err := keyring.Get(serviceName, v.GetString("username"))
 		if err == nil {
-			v.MergeConfigMap(map[string]interface{}{"password": password})
+			if err := v.MergeConfigMap(map[string]interface{}{"password": password}); err != nil {
+				return fmt.Errorf("unable to merge password from keyring: %w", err)
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,9 @@ const (
 
 	// env vars custom prefix
 	envPrefix = "UPCLOUD"
+
+	// serviceName is the name of the service
+	serviceName = "upctl"
 )
 
 var (
@@ -78,7 +81,7 @@ func (s *Config) Load() error {
 	v.SetEnvPrefix(envPrefix)
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	v.AutomaticEnv()
-	v.SetConfigName("upctl")
+	v.SetConfigName(serviceName)
 	v.SetConfigType("yaml")
 
 	configFile := s.GlobalFlags.ConfigFile
@@ -98,7 +101,7 @@ func (s *Config) Load() error {
 	}
 
 	if v.GetString("username") != "" && v.GetString("password") == "" {
-		password, err := keyring.Get("upctl", v.GetString("username"))
+		password, err := keyring.Get(serviceName, v.GetString("username"))
 		if err == nil {
 			v.MergeConfigMap(map[string]interface{}{"password": password})
 		}
@@ -205,7 +208,7 @@ func (s *Config) CreateService() (internal.AllServices, error) {
 		if s.GetString("config") != "" {
 			configDetails = fmt.Sprintf("used %s", s.GetString("config"))
 		}
-		return nil, clierrors.MissingCredentialsError{ConfigFile: configDetails}
+		return nil, clierrors.MissingCredentialsError{ConfigFile: configDetails, ServiceName: serviceName}
 	}
 
 	configs := []client.ConfigFn{
@@ -218,7 +221,7 @@ func (s *Config) CreateService() (internal.AllServices, error) {
 	}
 
 	client := client.New("", "", configs...)
-	client.UserAgent = fmt.Sprintf("upctl/%s", GetVersion())
+	client.UserAgent = fmt.Sprintf("%s/%s", serviceName, GetVersion())
 
 	svc := service.New(client)
 	return svc, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/clierrors"
 	internal "github.com/UpCloudLtd/upcloud-cli/v3/internal/service"
+	"github.com/zalando/go-keyring"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/client"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/service"
@@ -93,6 +94,13 @@ func (s *Config) Load() error {
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return fmt.Errorf("unable to parse config from file '%v': %w", v.ConfigFileUsed(), err)
+		}
+	}
+
+	if v.GetString("username") != "" && v.GetString("password") == "" {
+		password, err := keyring.Get("upctl", v.GetString("username"))
+		if err == nil {
+			v.MergeConfigMap(map[string]interface{}{"password": password})
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -64,6 +64,7 @@ func TestConfig_GetVersion(t *testing.T) {
 }
 
 func TestConfig_LoadKeyring(t *testing.T) {
+	// Note that configs defined in environment variables will override configs defined in the config file. Thus, this test will fail if credentials are currently defined as environment variables.
 	cfg := New()
 	tmpFile, err := os.CreateTemp(os.TempDir(), "")
 	assert.NoError(t, err)
@@ -76,7 +77,7 @@ func TestConfig_LoadKeyring(t *testing.T) {
 	cfg.GlobalFlags.ConfigFile = tmpFile.Name()
 	err = cfg.Load()
 	assert.NoError(t, err)
-	assert.NotEmpty(t, cfg.GetString("username"))
+	assert.Equal(t, cfg.GetString("username"), "unittest")
 	assert.Equal(t, "unittest_password", cfg.GetString("password"))
 	t.Cleanup(func() {
 		// remove test user from keyring

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,15 +67,19 @@ func TestConfig_LoadKeyring(t *testing.T) {
 	cfg := New()
 	tmpFile, err := os.CreateTemp(os.TempDir(), "")
 	assert.NoError(t, err)
-	_, err = tmpFile.WriteString("username: sdkfo")
+	_, err = tmpFile.WriteString("username: unittest")
 	assert.NoError(t, err)
 
-	err = keyring.Set("upctl", "sdkfo", "foo")
+	err = keyring.Set("upctl", "unittest", "unittest_password")
 	assert.NoError(t, err)
 
 	cfg.GlobalFlags.ConfigFile = tmpFile.Name()
 	err = cfg.Load()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cfg.GetString("username"))
-	assert.Equal(t, "foo", cfg.GetString("password"))
+	assert.Equal(t, "unittest_password", cfg.GetString("password"))
+	t.Cleanup(func() {
+		// remove everything related to upctl from keyring
+		assert.NoError(t, keyring.DeleteAll("upctl"))
+	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,7 +70,7 @@ func TestConfig_LoadKeyring(t *testing.T) {
 	_, err = tmpFile.WriteString("username: unittest")
 	assert.NoError(t, err)
 
-	err = keyring.Set("upctl", "unittest", "unittest_password")
+	err = keyring.Set("UpCloud", "unittest", "unittest_password")
 	assert.NoError(t, err)
 
 	cfg.GlobalFlags.ConfigFile = tmpFile.Name()
@@ -80,6 +80,6 @@ func TestConfig_LoadKeyring(t *testing.T) {
 	assert.Equal(t, "unittest_password", cfg.GetString("password"))
 	t.Cleanup(func() {
 		// remove test user from keyring
-		assert.NoError(t, keyring.Delete("upctl", "unittest"))
+		assert.NoError(t, keyring.Delete("UpCloud", "unittest"))
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -79,7 +79,7 @@ func TestConfig_LoadKeyring(t *testing.T) {
 	assert.NotEmpty(t, cfg.GetString("username"))
 	assert.Equal(t, "unittest_password", cfg.GetString("password"))
 	t.Cleanup(func() {
-		// remove everything related to upctl from keyring
-		assert.NoError(t, keyring.DeleteAll("upctl"))
+		// remove test user from keyring
+		assert.NoError(t, keyring.Delete("upctl", "unittest"))
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zalando/go-keyring"
 )
 
 func TestConfig_LoadInvalidYAML(t *testing.T) {
@@ -34,7 +35,7 @@ func TestConfig_Load(t *testing.T) {
 	assert.NotEmpty(t, cfg.GetString("password"))
 }
 
-func TestVersion(t *testing.T) {
+func TestConfig_GetVersion(t *testing.T) {
 	tests := []struct {
 		name     string
 		expected string
@@ -60,4 +61,21 @@ func TestVersion(t *testing.T) {
 			assert.Equal(t, test.expected, actual)
 		})
 	}
+}
+
+func TestConfig_LoadKeyring(t *testing.T) {
+	cfg := New()
+	tmpFile, err := os.CreateTemp(os.TempDir(), "")
+	assert.NoError(t, err)
+	_, err = tmpFile.WriteString("username: sdkfo")
+	assert.NoError(t, err)
+
+	err = keyring.Set("upctl", "sdkfo", "foo")
+	assert.NoError(t, err)
+
+	cfg.GlobalFlags.ConfigFile = tmpFile.Name()
+	err = cfg.Load()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, cfg.GetString("username"))
+	assert.Equal(t, "foo", cfg.GetString("password"))
 }


### PR DESCRIPTION
This PR adds initial support for the keyring.
I used [zalando/go-keyring](https://github.com/zalando/go-keyring) because of recent commits on repo (compared to [99designs/keyring](https://github.com/99designs/keyring)).
When I say initial, I mean it's open for discussion and adding more features (create auth command and save it to keyring?).

How it works:
If a username is set and the password is empty, check the keyring for service `upctl` where the username is coming either from the config file or env.
This type of logic does not break current.

Problem:
This PR does not read the username from the keyring, so it still needs a username from config or env. Maybe to introduce a config command `--keyring` ?

For me, it works by using UPCLOUD_USERNAME and creating username/password upctl services on keyring so I can switch easily between accounts without providing passwords. 


