### PR TITLE
feat(dbaas): add termination_protection to upctl database show

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: go-fmt
       # - id: go-vet
-      - id: go-lint
+      # - id: go-lint   # go-lint is deprecated https://github.com/golang/go/issues/38968
       - id: golangci-lint # implies go-vet, https://golangci-lint.run/usage/linters
       # - id: go-critic # run by golangci-lint, in order to configure
       - id: go-unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for Valkey properties
+- Add termination_protection to upctl database show output
 
 ## [3.14.0] - 2025-01-08
 

--- a/internal/commands/database/show.go
+++ b/internal/commands/database/show.go
@@ -71,6 +71,7 @@ func (s *showCommand) Execute(exec commands.Executor, uuid string) (output.Outpu
 				{Title: "Plan:", Value: db.Plan},
 				{Title: "Zone:", Value: db.Zone},
 				{Title: "State:", Value: db.State, Format: format.DatabaseState},
+				{Title: "Termination protection:", Value: db.TerminationProtection, Format: format.Boolean},
 			},
 		},
 		{


### PR DESCRIPTION
- Adding the termination protection field to the output of upctl database list
- Removing go-lint from precommit config file