### PR TITLE
chore(golangci-lint): avoid config deprecation warning

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,12 +40,10 @@ linters:
     - wastedassign
     - whitespace
 
-output:
-  uniq-by-line: false
-
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  uniq-by-line: false
   exclude-rules:
     - path: _test\.go
       linters:


### PR DESCRIPTION
uniq-by-line moved from output to issues in [1.63.0](https://golangci-lint.run/product/changelog/#v1630).