### PR TITLE
feat: sign checksums and containers with cosign

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ jobs:
   publish_release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
     steps:
       - name: Checkout head
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -32,6 +36,8 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
+      - name: Set up cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
       - name: Get tag version
         id: git
         run: echo "tag_version=$(make version)" >> "$GITHUB_OUTPUT"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,19 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
+signs:
+  - certificate: ${artifact}-keyless.pem
+    signature: ${artifact}-keyless.sig
+    cmd: cosign
+    args:
+      - sign-blob
+      - --b64=false
+      - --output-certificate=${certificate}
+      - --output-signature=${signature}
+      - --yes
+      - ${artifact}
+    artifacts: checksum
+
 snapshot:
   name_template: "{{ .Tag }}-next"
 
@@ -171,6 +184,13 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source=https://github.com/UpCloudLtd/upcloud-cli.git"
+
+docker_signs:
+  - args:
+      - sign
+      - --yes
+      - ${artifact}@${digest}
+    artifacts: all
 
 release:
   # Repo in which the release will be created.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,6 +8,6 @@
       - sets the version based on the tag
       - creates a draft release to GitHub
       - populates the release notes from `CHANGELOG.md` with `make release-notes`
-      - builds and uploads binaries & SHA sum for given release
+      - builds, uploads, and signs assets for given release
 5. Verify that [release notes](https://github.com/UpCloudLtd/upcloud-cli/releases) are in line with `CHANGELOG.MD`
 6. Publish the drafted release

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,45 @@ After installing `upctl`, you can run `upctl version` command to verify that the
 upctl version
 ```
 
+### Verify assets
+
+Project release packages' SHA-256 checksums are available in the project releases,
+files `checksums.txt`. They can be checked for example with:
+
+```sh
+# make sure at least one downloaded package and checksums.txt are in the current directory
+sha256sum -c --ignore-missing checksums.txt
+```
+
+Project release checksum files and Docker images are signed using the
+[Sigstore framework](https://www.sigstore.dev), and can be verified with
+[cosign](https://docs.sigstore.dev/cosign/).
+
+For example, to verify package checksums file for a release:
+
+```sh
+project_url=https://github.com/UpCloudLtd/upcloud-cli
+release=vX.Y.Z
+cosign verify-blob \
+    --certificate-identity ${project_url}/.github/workflows/publish.yml@refs/tags/${release} \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate ${project_url}/releases/download/${release}/checksums.txt-keyless.pem \
+    --signature ${project_url}/releases/download/${release}/checksums.txt-keyless.sig \
+    ${project_url}/releases/download/${release}/checksums.txt
+```
+
+And to verify the Docker image for a release:
+
+```sh
+project=UpCloudLtd/upcloud-cli
+release=vX.Y.Z
+cosign verify \
+   ghcr.io/${project}:${release} \
+   --certificate-identity https://github.com/${project}/.github/workflows/publish.yml@refs/tags/${release} \
+   --certificate-oidc-issuer https://token.actions.githubusercontent.com |
+   jq .
+```
+
 ### Configure shell completions
 
 `upctl` provides shell completions for multiple shells. Run `upctl completion --help` to list the supported shells.


### PR DESCRIPTION
Refs https://www.sigstore.dev, https://docs.sigstore.dev.

This makes use of cosign's identity-based/keyless mode: https://docs.sigstore.dev/cosign/signing/overview/

I have an example of this in action in my fork (which I've cut down to just the related parts to build and publish)
- Actions job: https://github.com/scop/upcloud-cli/actions/runs/13110600188/job/36573458825
- Release including the cosign related files (`checksums.txt-keyless.*`): https://github.com/scop/upcloud-cli/releases/tag/v0.0.0
- Docker images with the cosign related assets (`sha256-*.sig`): https://github.com/scop/upcloud-cli/pkgs/container/upcloud-cli
    - Looks like GH creates an example pull recipe using this signature file to the above packages page (`docker pull ghcr.io/.../upcloud-cli:sha256-*.sig`). That isn't ideal, but I don't know if it's that much of a concern. I wonder if there's a way to mark some of the images as the default from which this would be generated?

To try and verify the blobs and images in my fork above with cosign, tweak the project and release in the docs recipe accordingly.
<details>
```shell
project_url=https://github.com/scop/upcloud-cli
release=v0.0.0
cosign verify-blob \
    --certificate-identity ${project_url}/.github/workflows/publish.yml@refs/tags/${release} \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
    --certificate ${project_url}/releases/download/${release}/checksums.txt-keyless.pem \
    --signature ${project_url}/releases/download/${release}/checksums.txt-keyless.sig \
    ${project_url}/releases/download/${release}/checksums.txt
```

```shell
project=scop/upcloud-cli
release=v0.0.0
cosign verify \
   ghcr.io/${project}:${release} \
   --certificate-identity https://github.com/${project}/.github/workflows/publish.yml@refs/tags/${release} \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com |
   jq .
```
</details>

Once/if we have a future release out with these changes, I'll send a PR over to aqua-registry to make use of the signatures. After that is out with aqua and mise, installing with them will automatically verify the signatures and we can add a note to our docs about it (assuming we've merged #371 meanwhile).