### PR TITLE
fix: remove `v` prefix from version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Use correct currency symbol, `€` instead of `$`, in human output of `account show`.
+- Remove `v` prefix from version in `version` command output and User-Agent header
 
 ## [3.0.0] - 2023-10-18
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -216,6 +217,15 @@ func (s *Config) CreateService() (internal.AllServices, error) {
 }
 
 func GetVersion() string {
+	version := getVersion()
+	re := regexp.MustCompile(`v[0-9]+\.[0-9]+\.[0-9]+.*`)
+	if re.MatchString(version) {
+		return version[1:]
+	}
+	return version
+}
+
+func getVersion() string {
 	// Version was overridden during the build
 	if Version != "dev" {
 		return Version

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,3 +33,31 @@ func TestConfig_Load(t *testing.T) {
 	assert.NotEmpty(t, cfg.GetString("username"))
 	assert.NotEmpty(t, cfg.GetString("password"))
 }
+
+func TestVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		version  string
+	}{
+		{
+			name:     "Removes v prefix",
+			version:  "v1.2.3",
+			expected: "1.2.3",
+		},
+		{
+			name:     "Removes v prefix with suffix",
+			version:  "v1.2.3-rc1",
+			expected: "1.2.3-rc1",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			Version = test.version
+			actual := GetVersion()
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
The prefix is not used in pre-built packages. This removes it also when using go install.