### PR TITLE
chore(kubernetes): remove `server_number` column and hide deprecated plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Experimental support for reading password or token from system keyring.
 
+### Changed
+
+- In human readable output of `kubernetes plans`, remove `server_number` column and hide deprecated plans.
+
 ## [3.15.0] - 2025-02-26
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/UpCloudLtd/progress v1.0.2
-	github.com/UpCloudLtd/upcloud-go-api/v8 v8.16.0
+	github.com/UpCloudLtd/upcloud-go-api/v8 v8.16.1
 	github.com/adrg/xdg v0.3.2
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/gemalto/flume v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/UpCloudLtd/progress v1.0.2 h1:CTr1bBuFuXop9TEhR1PakbUMPTlUVL7Bgae9JgqXwPg=
 github.com/UpCloudLtd/progress v1.0.2/go.mod h1:iGxOnb9HvHW0yrLGUjHr0lxHhn7TehgWwh7a8NqK6iQ=
-github.com/UpCloudLtd/upcloud-go-api/v8 v8.16.0 h1:sF4RgPKdz5BgN+KMHeHTcTRxuq06cA/VIxV4Mcs/A6I=
-github.com/UpCloudLtd/upcloud-go-api/v8 v8.16.0/go.mod h1:bFnrOkfsDDmsb94nnBV5eSQjjsfDnwAzLnCt9+b4t/4=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.16.1 h1:U25DcnOcOWjKxXly9kB5bdrZRR8kdGqfLQHCgkk/T/g=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.16.1/go.mod h1:bFnrOkfsDDmsb94nnBV5eSQjjsfDnwAzLnCt9+b4t/4=
 github.com/adrg/xdg v0.3.2 h1:GUSGQ5pHdev83AYhDSS1A/CX+0JIsxbiWtow2DSA+RU=
 github.com/adrg/xdg v0.3.2/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/commands/kubernetes/plans.go
+++ b/internal/commands/kubernetes/plans.go
@@ -37,11 +37,12 @@ func (s *plansCommand) ExecuteWithoutArguments(exec commands.Executor) (output.O
 
 	rows := []output.TableRow{}
 	for _, plan := range plans {
-		rows = append(rows, output.TableRow{
-			plan.Name,
-			plan.ServerNumber,
-			plan.MaxNodes,
-		})
+		if !plan.Deprecated {
+			rows = append(rows, output.TableRow{
+				plan.Name,
+				plan.MaxNodes,
+			})
+		}
 	}
 
 	return output.MarshaledWithHumanOutput{
@@ -49,7 +50,6 @@ func (s *plansCommand) ExecuteWithoutArguments(exec commands.Executor) (output.O
 		Output: output.Table{
 			Columns: []output.TableColumn{
 				{Key: "name", Header: "Name"},
-				{Key: "server_number", Header: "Control nodes"},
 				{Key: "max_nodes", Header: "Max worker nodes"},
 			},
 			Rows: rows,


### PR DESCRIPTION
- [x] Depends on https://github.com/UpCloudLtd/upcloud-go-api/pull/357
- [x] Use released version of Go SDK