### PR TITLE
ci: add cleanup job to examples workflow

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -37,3 +37,25 @@ jobs:
           upctl version
           upctl account show > /dev/null # Ensure that credentials are valid
           mdtest examples/
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ always() }}
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - name: Install upctl
+        run: go install github.com/UpCloudLtd/upcloud-cli/v3/...@latest
+      - name: Purge resources
+        timeout-minutes: 5
+        env:
+          UPCLOUD_USERNAME: ${{ secrets.UPCLOUD_USERNAME }}
+          UPCLOUD_PASSWORD: ${{ secrets.UPCLOUD_PASSWORD }}
+        run: upctl all purge --include example-upctl-*
+      - name: List remaining resources
+        env:
+          UPCLOUD_USERNAME: ${{ secrets.UPCLOUD_USERNAME }}
+          UPCLOUD_PASSWORD: ${{ secrets.UPCLOUD_PASSWORD }}
+        run: upctl all list --include *tf-acc-test* --exclude *persistent*
+        if: ${{ failure() }}


### PR DESCRIPTION
- [x] Depends on https://github.com/UpCloudLtd/upcloud-cli/pull/393
- [x] Use latest as upctl version instead of the current commit hash