### PR TITLE
fix(runcommand): output correct invalid creds error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set exit code to 103 if authentication fails also in commands that do not take arguments (e.g. `server list`).
+
 ## [3.19.1] - 2025-04-29
 
 ### Fixed

--- a/internal/commands/runcommand.go
+++ b/internal/commands/runcommand.go
@@ -80,7 +80,14 @@ const (
 
 func resolveArguments(nc Command, exec Executor, args []string, mode resolveMode) (out []resolvedArgument, err error) {
 	if mode == resolveNone {
-		return nil, nil
+		acc := exec.Account()
+		if acc == nil {
+			// we don't have account service, nothing to validate
+			return nil, nil
+		}
+		// we only care about error here to report back any issue with auth
+		_, err := acc.GetAccount(exec.Context())
+		return nil, err
 	}
 
 	if resolve, ok := nc.(resolver.ResolutionProvider); ok {

--- a/internal/commands/runcommand_test.go
+++ b/internal/commands/runcommand_test.go
@@ -188,6 +188,7 @@ func TestRunCommand(t *testing.T) {
 				test.command.(*mockMulti).On("Execute", mock.Anything, mock.Anything).Return(output.OnlyMarshaled{Value: "mock"}, nil)
 			}
 			mService := &smock.Service{}
+			mService.On("GetAccount").Return(nil, nil)
 			cfg := config.New()
 			cfg.Viper().Set(config.KeyOutput, config.ValueOutputJSON)
 			// capture stdout
@@ -229,13 +230,15 @@ func TestRunCommand(t *testing.T) {
 }
 
 func TestExecute_Offline(t *testing.T) {
+	mService := &smock.Service{}
+	mService.On("GetAccount").Return(nil, nil)
 	cmd := &mockNone{Command: &cobra.Command{}}
 	cmd.On("ExecuteWithoutArguments", mock.Anything).Return(output.OnlyMarshaled{Value: "mock"}, nil)
 
 	cfg := config.New()
 	cfg.Viper().Set(config.KeyOutput, config.ValueOutputJSON)
 
-	err := commandRunE(cmd, nil, cfg, []string{})
+	err := commandRunE(cmd, mService, cfg, []string{})
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
closes #392 

The issue:
Invalid creds returns error at [runcommand.go](https://github.com/UpCloudLtd/upcloud-cli/blob/e7fda070e023cee2c674760d1d058bbb1b0b5575/internal/commands/runcommand.go#L119) only if resolver is used.
If the resolver is not used (ex., server list), it will go into the worker queue and render an error with error output. 
This is why some commands return expected output and some just an error message.

The fix:
output the error and stop progress log to print error message as other commands do without the resolver.