### PR TITLE
docs: add missing server create --simple-backup options

### DIFF
--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -284,7 +284,7 @@ Note that the default template, Ubuntu Server 24.04 LTS (Noble Numbat), only sup
 	fs.StringVar(&s.params.RemoteAccessPassword, "remote-access-password", def.RemoteAccessPassword, "Defines the remote access password.")
 	fs.StringVar(&s.params.RemoteAccessType, "remote-access-type", def.RemoteAccessType, "Set a remote access type. Available: vnc, spice")
 	fs.StringVar(&s.params.ServerGroup, "server-group", def.ServerGroup, "UUID of a server group for the server. To remove the server from the group, see `servergroup modify")
-	fs.StringVar(&s.params.SimpleBackup, "simple-backup", def.SimpleBackup, "Simple backup rule. Format (HHMM,{dailies,weeklies,monthlies}). Example: 2300,dailies")
+	fs.StringVar(&s.params.SimpleBackup, "simple-backup", def.SimpleBackup, "Simple backup rule. Format (HHMM,{daily,dailies,weeklies,monthlies,no}). Example: 2300,dailies")
 	fs.StringSliceVar(&s.params.sshKeys, "ssh-keys", def.sshKeys, "Add one or more SSH keys to the admin account. Accepted values are SSH public keys or filenames from where to read the keys.")
 	fs.StringArrayVar(&s.params.storages, "storage", def.storages, "A storage connected to the server, multiple can be declared.\nUsage: --storage action=attach,storage=01000000-0000-4000-8000-000020010301,type=cdrom")
 	fs.StringVar(&s.params.TimeZone, "time-zone", def.TimeZone, "Time zone to set the RTC to.")

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -284,7 +284,7 @@ Note that the default template, Ubuntu Server 24.04 LTS (Noble Numbat), only sup
 	fs.StringVar(&s.params.RemoteAccessPassword, "remote-access-password", def.RemoteAccessPassword, "Defines the remote access password.")
 	fs.StringVar(&s.params.RemoteAccessType, "remote-access-type", def.RemoteAccessType, "Set a remote access type. Available: vnc, spice")
 	fs.StringVar(&s.params.ServerGroup, "server-group", def.ServerGroup, "UUID of a server group for the server. To remove the server from the group, see `servergroup modify")
-	fs.StringVar(&s.params.SimpleBackup, "simple-backup", def.SimpleBackup, "Simple backup rule. Format (HHMM,{daily,dailies,weeklies,monthlies,no}). Example: 2300,dailies")
+	fs.StringVar(&s.params.SimpleBackup, "simple-backup", def.SimpleBackup, simpleBackupDescription)
 	fs.StringSliceVar(&s.params.sshKeys, "ssh-keys", def.sshKeys, "Add one or more SSH keys to the admin account. Accepted values are SSH public keys or filenames from where to read the keys.")
 	fs.StringArrayVar(&s.params.storages, "storage", def.storages, "A storage connected to the server, multiple can be declared.\nUsage: --storage action=attach,storage=01000000-0000-4000-8000-000020010301,type=cdrom")
 	fs.StringVar(&s.params.TimeZone, "time-zone", def.TimeZone, "Time zone to set the RTC to.")

--- a/internal/commands/server/modify.go
+++ b/internal/commands/server/modify.go
@@ -61,7 +61,7 @@ func (s *modifyCommand) InitCommand() {
 	config.AddEnableDisableFlags(flags, &s.setMetadata, "metadata", "metadata service")
 	// flags.StringVar(&s.params.metadata, "metadata", defaultModifyParams.metadata, "Enable metadata service.")
 	flags.StringVar(&s.params.Plan, "plan", defaultModifyParams.Plan, "Server plan to use.")
-	flags.StringVar(&s.params.SimpleBackup, "simple-backup", defaultModifyParams.SimpleBackup, "Simple backup rule. Format (HHMM,{dailies,weeklies,monthlies}).\nExample: 2300,dailies")
+	flags.StringVar(&s.params.SimpleBackup, "simple-backup", defaultModifyParams.SimpleBackup, simpleBackupDescription)
 	flags.StringVar(&s.params.Title, "title", defaultModifyParams.Title, "A short, informational description.")
 	flags.StringVar(&s.params.TimeZone, "time-zone", defaultModifyParams.TimeZone, "Time zone to set the RTC to.")
 	flags.StringVar(&s.params.VideoModel, "video-model", defaultModifyParams.VideoModel, "Video interface model of the server.\nAvailable: vga,cirrus")

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -19,8 +19,9 @@ const (
 	defaultRestartTimeoutAction = request.RestartTimeoutActionIgnore
 	customPlan                  = "custom"
 
-	avoidHostDescription = "Host to avoid when scheduling the server. Use this to make sure VMs do not reside on specific host. Refers to value from `host` attribute. Useful when building HA-environments."
-	hostDescription      = "Schedule the server on a specific host. Refers to value from `host` attribute. Only available in private clouds."
+	avoidHostDescription    = "Host to avoid when scheduling the server. Use this to make sure VMs do not reside on specific host. Refers to value from `host` attribute. Useful when building HA-environments."
+	hostDescription         = "Schedule the server on a specific host. Refers to value from `host` attribute. Only available in private clouds."
+	simpleBackupDescription = "Simple backup rule in `HHMM,{daily,dailies,weeklies,monthlies}` format or `no`. For example: `2300,dailies`."
 )
 
 // BaseServerCommand crestes the base "server" command


### PR DESCRIPTION
added missing `--simple-backup` options to `upctl server create` command

_"Simple backup time in UTC, followed by daily, dailies, weeklies, or monthlies option separated by comma, or no when disabled."_

Documentation sources:
https://upcloudltd.github.io/upcloud-cli/commands_reference/upctl_server/create/
https://developers.upcloud.com/1.3/8-servers/#attributes_5