### PR TITLE
feat(obs): extend support for object storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Object storage service creation with `object-storage create` command supporting labels, networks, and configured status
+- Object storage label management with dedicated commands: `object-storage label add`, `object-storage label remove`, and `object-storage label list`
+- Object storage network management with `object-storage network attach` and `object-storage network detach` commands
+- Object storage bucket management with `object-storage bucket create`, `object-storage bucket delete`, and `object-storage bucket list` commands
+- Object storage user management with `object-storage user create`, `object-storage user delete`, and `object-storage user list` commands
+- Object storage user access key management with `object-storage create-access-key`, `object-storage delete-access-key`, and `object-storage list-access-keys` commands
+
 ## [3.21.0] - 2025-07-15
 
 ### Added

--- a/examples/use_object_storage.md
+++ b/examples/use_object_storage.md
@@ -1,0 +1,54 @@
+# Using Object Storage with upctl
+
+This example demonstrates how to create and manage an object storage service, including managing buckets and configuring
+S3-compatible access via access keys.
+
+Set environment variables for convenience:
+
+```env
+prefix=example-upctl-
+region=europe-1
+```
+
+Create a managed object storage service:
+
+```sh
+upctl object-storage create --name ${prefix}service --network type=public,name=${prefix}network,family=IPv4 --region ${region}
+```
+
+List all buckets in your service (will be empty at this point):
+
+```sh
+upctl object-storage bucket list ${prefix}service
+```
+
+Create a new bucket:
+
+```sh
+upctl object-storage bucket create ${prefix}service --name ${prefix}bucket
+```
+
+Show details of the created bucket:
+
+```sh
+upctl object-storage bucket show ${prefix}service
+```
+
+Create a user and an access key for S3-compatible access:
+
+```sh
+upctl object-storage user create ${prefix}service --username ${prefix}user
+upctl object-storage access-key create ${prefix}service --username ${prefix}user
+```
+
+Once not needed anymore, delete the user:
+
+```sh
+upctl object-storage user delete ${prefix}service --username ${prefix}user
+```
+
+Delete also the managed object storage service along with its buckets:
+
+```sh
+upctl object-storage delete ${prefix}service --delete-buckets
+```

--- a/examples/use_object_storage.md
+++ b/examples/use_object_storage.md
@@ -28,12 +28,6 @@ Create a new bucket:
 upctl object-storage bucket create ${prefix}service --name ${prefix}bucket
 ```
 
-Show details of the created bucket:
-
-```sh
-upctl object-storage bucket show ${prefix}service
-```
-
 Create a user and an access key for S3-compatible access:
 
 ```sh

--- a/internal/commands/base/base.go
+++ b/internal/commands/base/base.go
@@ -19,6 +19,11 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/network"
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/networkpeering"
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/objectstorage"
+	objectstorageAccesskey "github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/objectstorage/accesskey"
+	objectstoragebucket "github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/objectstorage/bucket"
+	objectstoragelabel "github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/objectstorage/label"
+	objectstoragenetwork "github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/objectstorage/network"
+	objectstorageuser "github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/objectstorage/user"
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/partner"
 	partneraccount "github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/partner/account"
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/root"
@@ -212,10 +217,41 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 
 	// Managed object storage operations
 	objectStorageCommand := commands.BuildCommand(objectstorage.BaseobjectstorageCommand(), rootCmd, conf)
+	commands.BuildCommand(objectstorage.CreateCommand(), objectStorageCommand.Cobra(), conf)
 	commands.BuildCommand(objectstorage.DeleteCommand(), objectStorageCommand.Cobra(), conf)
 	commands.BuildCommand(objectstorage.ListCommand(), objectStorageCommand.Cobra(), conf)
 	commands.BuildCommand(objectstorage.ShowCommand(), objectStorageCommand.Cobra(), conf)
 	commands.BuildCommand(objectstorage.RegionsCommand(), objectStorageCommand.Cobra(), conf)
+
+	// Object storage user management
+	userCommand := commands.BuildCommand(objectstorageuser.BaseUserCommand(), objectStorageCommand.Cobra(), conf)
+	commands.BuildCommand(objectstorageuser.CreateCommand(), userCommand.Cobra(), conf)
+	commands.BuildCommand(objectstorageuser.DeleteCommand(), userCommand.Cobra(), conf)
+	commands.BuildCommand(objectstorageuser.ListCommand(), userCommand.Cobra(), conf)
+
+	// Object storage access key management
+	accessKeyCommand := commands.BuildCommand(objectstorageAccesskey.BaseAccessKeyCommand(), objectStorageCommand.Cobra(), conf)
+	commands.BuildCommand(objectstorageAccesskey.CreateCommand(), accessKeyCommand.Cobra(), conf)
+	commands.BuildCommand(objectstorageAccesskey.DeleteCommand(), accessKeyCommand.Cobra(), conf)
+	commands.BuildCommand(objectstorageAccesskey.ListCommand(), accessKeyCommand.Cobra(), conf)
+
+	// Object storage network management
+	objectStorageNetworkCommand := commands.BuildCommand(objectstoragenetwork.BaseNetworkCommand(), objectStorageCommand.Cobra(), conf)
+	commands.BuildCommand(objectstoragenetwork.AttachCommand(), objectStorageNetworkCommand.Cobra(), conf)
+	commands.BuildCommand(objectstoragenetwork.DetachCommand(), objectStorageNetworkCommand.Cobra(), conf)
+	commands.BuildCommand(objectstoragenetwork.ListCommand(), objectStorageNetworkCommand.Cobra(), conf)
+
+	// Object storage bucket management
+	bucketCommand := commands.BuildCommand(objectstoragebucket.BaseBucketCommand(), objectStorageCommand.Cobra(), conf)
+	commands.BuildCommand(objectstoragebucket.CreateCommand(), bucketCommand.Cobra(), conf)
+	commands.BuildCommand(objectstoragebucket.DeleteCommand(), bucketCommand.Cobra(), conf)
+	commands.BuildCommand(objectstoragebucket.ListCommand(), bucketCommand.Cobra(), conf)
+
+	// Object storage label management
+	labelCommand := commands.BuildCommand(objectstoragelabel.BaseLabelCommand(), objectStorageCommand.Cobra(), conf)
+	commands.BuildCommand(objectstoragelabel.AddCommand(), labelCommand.Cobra(), conf)
+	commands.BuildCommand(objectstoragelabel.RemoveCommand(), labelCommand.Cobra(), conf)
+	commands.BuildCommand(objectstoragelabel.ListCommand(), labelCommand.Cobra(), conf)
 
 	// Network Gateway operations
 	gatewayCommand := commands.BuildCommand(gateway.BaseGatewayCommand(), rootCmd, conf)

--- a/internal/commands/objectstorage/accesskey/accesskey.go
+++ b/internal/commands/objectstorage/accesskey/accesskey.go
@@ -1,0 +1,16 @@
+package accesskey
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+)
+
+// BaseAccessKeyCommand creates the base "object-storage access-key" command
+func BaseAccessKeyCommand() commands.Command {
+	return &accessKeyCommand{
+		BaseCommand: commands.New("access-key", "Manage access keys in managed object storage services"),
+	}
+}
+
+type accessKeyCommand struct {
+	*commands.BaseCommand
+}

--- a/internal/commands/objectstorage/accesskey/create.go
+++ b/internal/commands/objectstorage/accesskey/create.go
@@ -1,0 +1,71 @@
+package accesskey
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// CreateCommand creates the 'object-storage access-key create' command
+func CreateCommand() commands.Command {
+	return &createCommand{
+		BaseCommand: commands.New(
+			"create",
+			"Create an access key for a user in managed object storage service",
+			"upctl object-storage access-key create <service-uuid> --username myuser",
+			"upctl object-storage access-key create my-service --username myuser",
+		),
+	}
+}
+
+type createCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	params request.CreateManagedObjectStorageUserAccessKeyRequest
+}
+
+// InitCommand implements Command.InitCommand
+func (s *createCommand) InitCommand() {
+	s.Cobra().Long = commands.WrapLongDescription(`Create an access key for a user in managed object storage service\n\nCreates a new access key for the specified user in a managed object storage service. The access key can be used to authenticate API requests to the object storage service. Note that the secret access key is only shown once during creation and cannot be retrieved later.`)
+
+	fs := s.Cobra().Flags()
+	fs.StringVar(&s.params.Username, "username", "", "The username to create the access key for.")
+	commands.Must(s.Cobra().MarkFlagRequired("username"))
+}
+
+// Execute implements Command.Execute
+func (s *createCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	s.params.ServiceUUID = serviceUUID
+
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Creating access key for user %v in service %v", s.params.Username, s.params.ServiceUUID)
+	exec.PushProgressStarted(msg)
+
+	res, err := svc.CreateManagedObjectStorageUserAccessKey(exec.Context(), &s.params)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	// Handle SecretAccessKey which might be a pointer
+	var secretKey interface{}
+	if res.SecretAccessKey != nil {
+		secretKey = *res.SecretAccessKey
+	} else {
+		secretKey = ""
+	}
+
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "Access Key ID", Value: res.AccessKeyID},
+		{Title: "Secret Access Key", Value: secretKey},
+		{Title: "Status", Value: res.Status},
+		{Title: "Created At", Value: res.CreatedAt},
+	}}, nil
+}

--- a/internal/commands/objectstorage/accesskey/delete.go
+++ b/internal/commands/objectstorage/accesskey/delete.go
@@ -1,0 +1,61 @@
+package accesskey
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// DeleteCommand creates the 'object-storage access-key delete' command
+func DeleteCommand() commands.Command {
+	return &deleteCommand{
+		BaseCommand: commands.New(
+			"delete",
+			"Delete an access key from a user in managed object storage service",
+			"upctl object-storage access-key delete <service-uuid> --username myuser --access-key-id AKIAIOSFODNN7EXAMPLE",
+			"upctl object-storage access-key delete my-service --username myuser --access-key-id AKIAIOSFODNN7EXAMPLE",
+		),
+	}
+}
+
+type deleteCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	params request.DeleteManagedObjectStorageUserAccessKeyRequest
+}
+
+// InitCommand implements Command.InitCommand
+func (s *deleteCommand) InitCommand() {
+	s.Cobra().Long = commands.WrapLongDescription(`Delete an access key from a user in managed object storage service\n\nDeletes the specified access key from the user in the managed object storage service. The access key will be permanently deleted and can no longer be used for authentication.`)
+
+	fs := s.Cobra().Flags()
+	fs.StringVar(&s.params.Username, "username", "", "Username that owns the access key")
+	fs.StringVar(&s.params.AccessKeyID, "access-key-id", "", "Access key ID to delete")
+
+	commands.Must(s.Cobra().MarkFlagRequired("username"))
+	commands.Must(s.Cobra().MarkFlagRequired("access-key-id"))
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *deleteCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	s.params.ServiceUUID = serviceUUID
+
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Deleting access key %s for user %s from service %s", s.params.AccessKeyID, s.params.Username, serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	err := svc.DeleteManagedObjectStorageUserAccessKey(exec.Context(), &s.params)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	return output.OnlyMarshaled{Value: fmt.Sprintf("Access key %s deleted for user %s from service %s", s.params.AccessKeyID, s.params.Username, serviceUUID)}, nil
+}

--- a/internal/commands/objectstorage/accesskey/list.go
+++ b/internal/commands/objectstorage/accesskey/list.go
@@ -1,0 +1,77 @@
+package accesskey
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// ListCommand creates the 'object-storage access-key list' command
+func ListCommand() commands.Command {
+	return &listCommand{
+		BaseCommand: commands.New(
+			"list",
+			"List access keys for a user in managed object storage service",
+			"upctl object-storage access-key list <service-uuid> --username myuser",
+			"upctl object-storage access-key list my-service --username myuser",
+		),
+	}
+}
+
+type listCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	params request.GetManagedObjectStorageUserAccessKeysRequest
+}
+
+// InitCommand implements Command.InitCommand
+func (s *listCommand) InitCommand() {
+	s.Cobra().Long = commands.WrapLongDescription(`List access keys for a user in managed object storage service\n\nLists all access keys for the specified user in the managed object storage service. This helps you find the access key IDs needed for deletion.`)
+
+	fs := s.Cobra().Flags()
+	fs.StringVar(&s.params.Username, "username", "", "The username of the user to list access keys from.")
+	commands.Must(s.Cobra().MarkFlagRequired("username"))
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *listCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
+	s.params.ServiceUUID = uuid
+
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Listing access keys for user %s in service %s", s.params.Username, uuid)
+	exec.PushProgressStarted(msg)
+
+	res, err := svc.GetManagedObjectStorageUserAccessKeys(exec.Context(), &s.params)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	rows := []output.TableRow{}
+	for _, accessKey := range res {
+		rows = append(rows, output.TableRow{
+			accessKey.AccessKeyID,
+			accessKey.Status,
+			accessKey.CreatedAt.String(),
+		})
+	}
+
+	return output.MarshaledWithHumanOutput{
+		Value: res,
+		Output: output.Table{
+			Columns: []output.TableColumn{
+				{Key: "access_key_id", Header: "Access Key ID"},
+				{Key: "status", Header: "Status"},
+				{Key: "created_at", Header: "Created"},
+			},
+			Rows: rows,
+		},
+	}, nil
+}

--- a/internal/commands/objectstorage/bucket/bucket.go
+++ b/internal/commands/objectstorage/bucket/bucket.go
@@ -1,0 +1,16 @@
+package bucket
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+)
+
+// BaseBucketCommand creates the base "object-storage bucket" command
+func BaseBucketCommand() commands.Command {
+	return &bucketCommand{
+		BaseCommand: commands.New("bucket", "Manage buckets in managed object storage services"),
+	}
+}
+
+type bucketCommand struct {
+	*commands.BaseCommand
+}

--- a/internal/commands/objectstorage/bucket/create.go
+++ b/internal/commands/objectstorage/bucket/create.go
@@ -54,6 +54,5 @@ func (s *createCommand) ExecuteSingleArgument(exec commands.Executor, serviceUUI
 
 	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
 		{Title: "Name", Value: res.Name},
-		{Title: "Total Size Bytes", Value: res.TotalSizeBytes},
 	}}, nil
 }

--- a/internal/commands/objectstorage/bucket/create.go
+++ b/internal/commands/objectstorage/bucket/create.go
@@ -1,0 +1,59 @@
+package bucket
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// CreateCommand creates the 'objectstorage bucket create' command
+func CreateCommand() commands.Command {
+	return &createCommand{
+		BaseCommand: commands.New(
+			"create",
+			"Create a bucket in managed object storage service",
+			"upctl object-storage bucket create 012345...789 --name my-bucket",
+			"upctl object-storage bucket create my-service --name my-bucket",
+		),
+	}
+}
+
+type createCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	params request.CreateManagedObjectStorageBucketRequest
+}
+
+// InitCommand implements Command.InitCommand
+func (s *createCommand) InitCommand() {
+	fs := s.Cobra().Flags()
+	fs.StringVar(&s.params.Name, "name", "", "The name of the bucket.")
+	commands.Must(s.Cobra().MarkFlagRequired("name"))
+}
+
+// ExecuteSingleArgument implements Command.SingleArgumentCommand
+func (s *createCommand) ExecuteSingleArgument(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	s.params.ServiceUUID = serviceUUID
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Creating bucket %v in service %v", s.params.Name, s.params.ServiceUUID)
+	exec.PushProgressStarted(msg)
+
+	res, err := svc.CreateManagedObjectStorageBucket(exec.Context(), &s.params)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "Name", Value: res.Name},
+		{Title: "Total Size Bytes", Value: res.TotalSizeBytes},
+	}}, nil
+}

--- a/internal/commands/objectstorage/bucket/delete.go
+++ b/internal/commands/objectstorage/bucket/delete.go
@@ -1,0 +1,57 @@
+package bucket
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// DeleteCommand creates the 'objectstorage bucket delete' command
+func DeleteCommand() commands.Command {
+	return &deleteCommand{
+		BaseCommand: commands.New(
+			"delete",
+			"Delete a bucket from a managed object storage service",
+			"upctl object-storage bucket delete <service-uuid> --name my-bucket",
+			"upctl object-storage bucket delete my-service --name my-bucket",
+		),
+	}
+}
+
+type deleteCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	params request.DeleteManagedObjectStorageBucketRequest
+}
+
+// InitCommand implements Command.InitCommand
+func (s *deleteCommand) InitCommand() {
+	fs := s.Cobra().Flags()
+	fs.StringVar(&s.params.Name, "name", "", "The name of the bucket to delete.")
+	commands.Must(s.Cobra().MarkFlagRequired("name"))
+}
+
+// Execute implements Command.Execute
+func (s *deleteCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	s.params.ServiceUUID = serviceUUID
+
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Deleting bucket %s from service %s", s.params.Name, serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	err := svc.DeleteManagedObjectStorageBucket(exec.Context(), &s.params)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	return output.OnlyMarshaled{Value: fmt.Sprintf("Bucket %s deleted from service %s", s.params.Name, serviceUUID)}, nil
+}

--- a/internal/commands/objectstorage/bucket/list.go
+++ b/internal/commands/objectstorage/bucket/list.go
@@ -1,0 +1,74 @@
+package bucket
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// ListCommand creates the 'objectstorage bucket list' command
+func ListCommand() commands.Command {
+	return &listCommand{
+		BaseCommand: commands.New(
+			"list",
+			"List buckets in a managed object storage service",
+			"upctl object-storage bucket list <service-uuid>",
+			"upctl object-storage bucket list my-service",
+		),
+	}
+}
+
+type listCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+}
+
+// InitCommand implements Command.InitCommand
+func (s *listCommand) InitCommand() {
+	s.Cobra().Long = commands.WrapLongDescription(`List buckets in a managed object storage service
+
+Lists all buckets in the specified managed object storage service, showing their names and total size in bytes.`)
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *listCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Listing buckets in service %s", serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	req := &request.GetManagedObjectStorageBucketMetricsRequest{
+		ServiceUUID: serviceUUID,
+	}
+
+	res, err := svc.GetManagedObjectStorageBucketMetrics(exec.Context(), req)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	rows := []output.TableRow{}
+	for _, bucket := range res {
+		rows = append(rows, output.TableRow{
+			bucket.Name,
+			fmt.Sprintf("%d", bucket.TotalSizeBytes),
+		})
+	}
+
+	return output.MarshaledWithHumanOutput{
+		Value: res,
+		Output: output.Table{
+			Columns: []output.TableColumn{
+				{Key: "name", Header: "Name"},
+				{Key: "total_size_bytes", Header: "Total Size Bytes"},
+			},
+			Rows: rows,
+		},
+	}, nil
+}

--- a/internal/commands/objectstorage/create.go
+++ b/internal/commands/objectstorage/create.go
@@ -1,0 +1,184 @@
+package objectstorage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/UpCloudLtd/progress/messages"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/config"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/labels"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/ui"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// CreateCommand creates the 'objectstorage create' command
+func CreateCommand() commands.Command {
+	return &createCommand{
+		BaseCommand: commands.New(
+			"create",
+			"Create a new managed object storage service",
+			"upctl object-storage create --name my-service --region europe-1",
+			"upctl object-storage create --name my-service --region europe-1 --configured-status started",
+		),
+	}
+}
+
+type createCommand struct {
+	*commands.BaseCommand
+	params           request.CreateManagedObjectStorageRequest
+	wait             config.OptionalBoolean
+	labels           []string
+	networks         []string
+	configuredStatus string
+}
+
+// InitCommand implements Command.InitCommand
+func (s *createCommand) InitCommand() {
+	s.Cobra().Long = commands.WrapLongDescription(`Create a new managed object storage service
+
+Creates a new managed object storage service in the specified region. The service can be started or stopped based on the configured status.`)
+
+	fs := s.Cobra().Flags()
+
+	fs.StringVar(&s.params.Name, "name", "", "The name of the service. Must be unique within customer account.")
+	fs.StringVar(&s.params.Region, "region", "", "Region in which the service will be hosted.")
+	fs.StringVar(&s.configuredStatus, "configured-status", "started", "Service status managed by the customer. Valid values: started, stopped")
+	fs.StringArrayVar(&s.labels, "label", nil, "Labels to describe the service in `key=value` format, multiple can be declared.\nUsage: --label env=dev\n\n--label owner=operations")
+	fs.StringArrayVar(&s.networks, "network", nil, "Networks for the service. At least one network is needed. If not specified, a public network will be used by default.\nNote: Only one public network is allowed per service, but multiple private networks are supported.\nPublic network: --network type=public,name=my-public-network,family=IPv4\nPrivate network: --network type=private,name=my-private-network,family=IPv4,uuid=03fc6b80-9039-4bb7-ae43-5ccbe0ae35ce")
+	config.AddToggleFlag(fs, &s.wait, "wait", false, "Wait for service to be in running state before returning.")
+
+	commands.Must(s.Cobra().MarkFlagRequired("name"))
+	commands.Must(s.Cobra().MarkFlagRequired("region"))
+}
+
+// ExecuteWithoutArguments implements commands.NoArgumentCommand
+func (s *createCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
+	if s.configuredStatus != "started" && s.configuredStatus != "stopped" {
+		return nil, fmt.Errorf("configured-status must be either 'started' or 'stopped'")
+	}
+	s.params.ConfiguredStatus = upcloud.ManagedObjectStorageConfiguredStatus(s.configuredStatus)
+
+	svc := exec.All()
+	msg := fmt.Sprintf("Creating object storage service %v", s.params.Name)
+	exec.PushProgressStarted(msg)
+
+	// Process networks
+	networks, err := s.processNetworks()
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate network constraints
+	err = s.validateCreateNetworks(networks)
+	if err != nil {
+		return nil, err
+	}
+
+	// If no networks provided, add a default public network
+	if len(networks) == 0 {
+		networks = []upcloud.ManagedObjectStorageNetwork{
+			{
+				Family: "IPv4",
+				Name:   fmt.Sprintf("%s-public-network", s.params.Name),
+				Type:   "public",
+			},
+		}
+	}
+
+	s.params.Networks = networks
+
+	// Process labels
+	labelSlice, err := labels.StringsToSliceOfLabels(s.labels)
+	if err != nil {
+		return nil, err
+	}
+	s.params.Labels = labelSlice
+
+	res, err := svc.CreateManagedObjectStorage(exec.Context(), &s.params)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	if s.wait.Value() {
+		waitForObjectStorageServiceState(res.UUID, upcloud.ManagedObjectStorageOperationalStateRunning, exec, msg)
+	} else {
+		exec.PushProgressSuccess(msg)
+	}
+
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "UUID", Value: res.UUID, Colour: ui.DefaultUUUIDColours},
+		{Title: "Name", Value: res.Name},
+		{Title: "Region", Value: res.Region},
+	}}, nil
+}
+
+func (s *createCommand) processNetworks() ([]upcloud.ManagedObjectStorageNetwork, error) {
+	var networks []upcloud.ManagedObjectStorageNetwork
+	for _, n := range s.networks {
+		var network upcloud.ManagedObjectStorageNetwork
+		parts := strings.Split(n, ",")
+		for _, part := range parts {
+			kv := strings.SplitN(part, "=", 2)
+			if len(kv) != 2 {
+				return nil, fmt.Errorf("invalid network format: %s", part)
+			}
+			key, value := kv[0], kv[1]
+			switch key {
+			case "type":
+				network.Type = value
+			case "name":
+				network.Name = value
+			case "family":
+				network.Family = value
+			case "uuid":
+				network.UUID = &value
+			}
+		}
+		networks = append(networks, network)
+	}
+	return networks, nil
+}
+
+func (s *createCommand) validateCreateNetworks(networks []upcloud.ManagedObjectStorageNetwork) error {
+	var publicNetworkCount int
+	for _, n := range networks {
+		if n.Type == "public" {
+			publicNetworkCount++
+		}
+	}
+	if publicNetworkCount > 1 {
+		return fmt.Errorf("only one public network is allowed per service")
+	}
+
+	return nil
+}
+
+// waitForObjectStorageServiceState waits for object storage service to reach given state and updates progress message with key matching given msg. Finally, progress message is updated back to given msg and either done state or timeout warning.
+func waitForObjectStorageServiceState(uuid string, state upcloud.ManagedObjectStorageOperationalState, exec commands.Executor, msg string) {
+	exec.PushProgressUpdateMessage(msg, fmt.Sprintf("Waiting for object storage service %s to be in %s state", uuid, state))
+
+	ctx, cancel := context.WithTimeout(exec.Context(), 15*time.Minute)
+	defer cancel()
+
+	if _, err := exec.All().WaitForManagedObjectStorageOperationalState(ctx, &request.WaitForManagedObjectStorageOperationalStateRequest{
+		UUID:         uuid,
+		DesiredState: state,
+	}); err != nil {
+		exec.PushProgressUpdate(messages.Update{
+			Key:     msg,
+			Message: msg,
+			Status:  messages.MessageStatusWarning,
+			Details: "Error: " + err.Error(),
+		})
+		return
+	}
+
+	exec.PushProgressUpdateMessage(msg, msg)
+	exec.PushProgressSuccess(msg)
+}

--- a/internal/commands/objectstorage/label/add.go
+++ b/internal/commands/objectstorage/label/add.go
@@ -1,0 +1,123 @@
+package label
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/labels"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/ui"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// AddCommand creates the 'objectstorage label add' command
+func AddCommand() commands.Command {
+	return &addCommand{
+		BaseCommand: commands.New(
+			"add",
+			"Add labels to a managed object storage service",
+			"upctl object-storage label add <service-uuid> --label env=production --label team=backend",
+			"upctl object-storage label add my-service --label env=production",
+		),
+	}
+}
+
+type addCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	labelStrings []string
+}
+
+// InitCommand implements Command.InitCommand
+func (s *addCommand) InitCommand() {
+	fs := s.Cobra().Flags()
+	fs.StringArrayVar(&s.labelStrings, "label", nil, "Labels to add in `key=value` format, multiple can be declared.\nUsage: --label env=dev --label owner=operations")
+}
+
+// Execute implements Command.Execute
+func (s *addCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	if len(s.labelStrings) == 0 {
+		return nil, fmt.Errorf("at least one label must be specified")
+	}
+
+	// Parse labels
+	newLabels, err := labels.StringsToSliceOfLabels(s.labelStrings)
+	if err != nil {
+		return nil, err
+	}
+
+	svc := exec.All()
+
+	// Get current service to merge labels
+	getReq := &request.GetManagedObjectStorageRequest{UUID: serviceUUID}
+	current, err := svc.GetManagedObjectStorage(exec.Context(), getReq)
+	if err != nil {
+		return commands.HandleError(exec, "Failed to get current service", err)
+	}
+
+	// Merge existing labels with new ones
+	mergedLabels := mergeLabels(current.Labels, newLabels)
+
+	// Update the service
+	msg := fmt.Sprintf("Adding labels to object storage service %s", serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	modifyReq := &request.ModifyManagedObjectStorageRequest{
+		UUID:   serviceUUID,
+		Labels: &mergedLabels,
+	}
+	// TODO: update to use dedicated labels endpoint when available
+	res, err := svc.ModifyManagedObjectStorage(exec.Context(), modifyReq)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	combined := output.Combined{
+		output.CombinedSection{
+			Contents: output.Details{
+				Sections: []output.DetailSection{
+					{
+						Title: "Overview:",
+						Rows: []output.DetailRow{
+							{Title: "UUID:", Value: res.UUID, Colour: ui.DefaultUUUIDColours},
+							{Title: "Name:", Value: res.Name},
+						},
+					},
+				},
+			},
+		},
+		labels.GetLabelsSectionWithResourceType(res.Labels, "managed object storage"),
+	}
+
+	return output.MarshaledWithHumanOutput{
+		Value:  res,
+		Output: combined,
+	}, nil
+}
+
+// mergeLabels merges existing labels with new labels, with new labels taking precedence
+func mergeLabels(existing []upcloud.Label, newLabels []upcloud.Label) []upcloud.Label {
+	labelMap := make(map[string]string)
+
+	// Add existing labels
+	for _, label := range existing {
+		labelMap[label.Key] = label.Value
+	}
+
+	// Add/override with new labels
+	for _, label := range newLabels {
+		labelMap[label.Key] = label.Value
+	}
+
+	// Convert back to slice
+	var result []upcloud.Label
+	for key, value := range labelMap {
+		result = append(result, upcloud.Label{Key: key, Value: value})
+	}
+	return result
+}

--- a/internal/commands/objectstorage/label/add.go
+++ b/internal/commands/objectstorage/label/add.go
@@ -77,6 +77,8 @@ func (s *addCommand) Execute(exec commands.Executor, serviceUUID string) (output
 		return commands.HandleError(exec, msg, err)
 	}
 
+	exec.PushProgressSuccess(msg)
+
 	combined := output.Combined{
 		output.CombinedSection{
 			Contents: output.Details{

--- a/internal/commands/objectstorage/label/label.go
+++ b/internal/commands/objectstorage/label/label.go
@@ -1,0 +1,16 @@
+package label
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+)
+
+// BaseLabelCommand creates the base "object-storage label" command
+func BaseLabelCommand() commands.Command {
+	return &labelCommand{
+		BaseCommand: commands.New("label", "Manage labels in managed object storage services"),
+	}
+}
+
+type labelCommand struct {
+	*commands.BaseCommand
+}

--- a/internal/commands/objectstorage/label/list.go
+++ b/internal/commands/objectstorage/label/list.go
@@ -1,0 +1,50 @@
+package label
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/labels"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// ListCommand creates the 'objectstorage label list' command
+func ListCommand() commands.Command {
+	return &listCommand{
+		BaseCommand: commands.New(
+			"list",
+			"List labels for a managed object storage service",
+			"upctl object-storage label list <service-uuid>",
+			"upctl object-storage label list my-service",
+		),
+	}
+}
+
+type listCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+}
+
+// Execute implements Command.Execute
+func (s *listCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	svc := exec.All()
+
+	msg := "Listing labels for object storage service " + serviceUUID
+	exec.PushProgressStarted(msg)
+
+	// Get the service to access its labels
+	getReq := &request.GetManagedObjectStorageRequest{UUID: serviceUUID}
+	service, err := svc.GetManagedObjectStorage(exec.Context(), getReq)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	// Use the existing labels formatting from the labels package
+	section := labels.GetLabelsSectionWithResourceType(service.Labels, "managed object storage")
+	return output.Combined{section}, nil
+}

--- a/internal/commands/objectstorage/label/remove.go
+++ b/internal/commands/objectstorage/label/remove.go
@@ -1,0 +1,114 @@
+package label
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/labels"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/ui"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// RemoveCommand creates the 'objectstorage label remove' command
+func RemoveCommand() commands.Command {
+	return &removeCommand{
+		BaseCommand: commands.New(
+			"remove",
+			"Remove labels from a managed object storage service",
+			"upctl object-storage label remove <service-uuid> --key env --key team",
+			"upctl object-storage label remove my-service --key env",
+		),
+	}
+}
+
+type removeCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	labelKeys []string
+}
+
+// InitCommand implements Command.InitCommand
+func (s *removeCommand) InitCommand() {
+	fs := s.Cobra().Flags()
+	fs.StringArrayVar(&s.labelKeys, "key", nil, "Label keys to remove, multiple can be declared.\nUsage: --key env --key owner")
+}
+
+// Execute implements Command.Execute
+func (s *removeCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	if len(s.labelKeys) == 0 {
+		return nil, fmt.Errorf("at least one label key must be specified")
+	}
+
+	svc := exec.All()
+
+	// Get current service to get existing labels
+	getReq := &request.GetManagedObjectStorageRequest{UUID: serviceUUID}
+	current, err := svc.GetManagedObjectStorage(exec.Context(), getReq)
+	if err != nil {
+		return commands.HandleError(exec, "Failed to get current service", err)
+	}
+
+	// Remove specified labels
+	updatedLabels := removeLabels(current.Labels, s.labelKeys)
+
+	// Update the service
+	msg := fmt.Sprintf("Removing labels from object storage service %s", serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	modifyReq := &request.ModifyManagedObjectStorageRequest{
+		UUID:   serviceUUID,
+		Labels: &updatedLabels,
+	}
+
+	// TODO: update to use dedicated labels endpoint when available
+	res, err := svc.ModifyManagedObjectStorage(exec.Context(), modifyReq)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	combined := output.Combined{
+		output.CombinedSection{
+			Contents: output.Details{
+				Sections: []output.DetailSection{
+					{
+						Title: "Overview:",
+						Rows: []output.DetailRow{
+							{Title: "UUID:", Value: res.UUID, Colour: ui.DefaultUUUIDColours},
+							{Title: "Name:", Value: res.Name},
+						},
+					},
+				},
+			},
+		},
+		labels.GetLabelsSectionWithResourceType(res.Labels, "managed object storage"),
+	}
+
+	return output.MarshaledWithHumanOutput{
+		Value:  res,
+		Output: combined,
+	}, nil
+}
+
+// removeLabels removes labels with specified keys from the existing labels
+func removeLabels(existing []upcloud.Label, keysToRemove []string) []upcloud.Label {
+	removeSet := make(map[string]bool)
+	for _, key := range keysToRemove {
+		removeSet[key] = true
+	}
+
+	var result []upcloud.Label
+	for _, label := range existing {
+		if !removeSet[label.Key] {
+			result = append(result, label)
+		}
+	}
+	return result
+}

--- a/internal/commands/objectstorage/list.go
+++ b/internal/commands/objectstorage/list.go
@@ -27,18 +27,10 @@ func (c *listCommand) InitCommand() {
 	fs := &pflag.FlagSet{}
 	c.ConfigureFlags(fs)
 	c.AddFlags(fs)
-
-	// Deprecating objectstorage and objsto in favour of object-storage
-	// TODO: Remove this in the future
-	commands.SetSubcommandDeprecationHelp(c, []string{"objectstorage", "objsto"})
 }
 
 // ExecuteWithoutArguments implements commands.NoArgumentCommand
 func (c *listCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
-	// Deprecating objectstorage and objsto in favour of object-storage
-	// TODO: Remove this in the future
-	commands.SetSubcommandExecutionDeprecationMessage(c, []string{"objectstorage", "objsto"}, "object-storage")
-
 	svc := exec.All()
 	objectstorages, err := svc.GetManagedObjectStorages(exec.Context(), &request.GetManagedObjectStoragesRequest{
 		Page: c.Page(),

--- a/internal/commands/objectstorage/network/attach.go
+++ b/internal/commands/objectstorage/network/attach.go
@@ -1,0 +1,73 @@
+package network
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// AttachCommand creates the 'objectstorage network attach' command
+func AttachCommand() commands.Command {
+	return &attachCommand{
+		BaseCommand: commands.New(
+			"attach",
+			"Attach a network to a managed object storage service",
+			"upctl object-storage network attach <service-uuid> --type public --name my-public-net --family IPv4",
+			"upctl object-storage network attach <service-uuid> --type private --name my-private-net --family IPv4 --uuid 03fc6b80-9039-4bb7-ae43-5ccbe0ae35ce",
+		),
+	}
+}
+
+type attachCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	params        request.CreateManagedObjectStorageNetworkRequest
+	networkUUID   string
+	networkType   string
+	networkName   string
+	networkFamily string
+}
+
+// InitCommand implements Command.InitCommand
+func (s *attachCommand) InitCommand() {
+	fs := s.Cobra().Flags()
+	fs.StringVar(&s.networkUUID, "network", "", "The UUID of the network to attach.")
+	fs.StringVar(&s.networkType, "type", "", "The type of network (public or private).")
+	fs.StringVar(&s.networkName, "name", "", "The name for the network.")
+	fs.StringVar(&s.networkFamily, "family", "", "The IP family for the network (IPv4 or IPv6).")
+	commands.Must(s.Cobra().MarkFlagRequired("network"))
+	commands.Must(s.Cobra().MarkFlagRequired("type"))
+	commands.Must(s.Cobra().MarkFlagRequired("name"))
+	commands.Must(s.Cobra().MarkFlagRequired("family"))
+}
+
+// Execute implements Command.Execute
+func (s *attachCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	svc := exec.All()
+
+	msg := "Attaching network " + s.networkUUID + " to service " + serviceUUID
+	exec.PushProgressStarted(msg)
+
+	// Use the dedicated network creation endpoint
+	s.params.ServiceUUID = serviceUUID
+	s.params.UUID = s.networkUUID
+	s.params.Type = s.networkType
+	s.params.Name = s.networkName
+	s.params.Family = s.networkFamily
+
+	res, err := svc.CreateManagedObjectStorageNetwork(exec.Context(), &s.params)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "Network UUID", Value: s.networkUUID},
+		{Title: "Service UUID", Value: serviceUUID},
+	}}, nil
+}

--- a/internal/commands/objectstorage/network/detach.go
+++ b/internal/commands/objectstorage/network/detach.go
@@ -1,0 +1,56 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// DetachCommand creates the 'objectstorage network detach' command
+func DetachCommand() commands.Command {
+	return &detachCommand{
+		BaseCommand: commands.New(
+			"detach",
+			"Detach a network from a managed object storage service",
+			"upctl object-storage network detach <service-uuid> --name my-network",
+		),
+	}
+}
+
+type detachCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	params request.DeleteManagedObjectStorageNetworkRequest
+}
+
+// InitCommand implements Command.InitCommand
+func (s *detachCommand) InitCommand() {
+	fs := s.Cobra().Flags()
+	fs.StringVar(&s.params.NetworkName, "name", "", "The name of the network to detach.")
+	commands.Must(s.Cobra().MarkFlagRequired("name"))
+}
+
+// Execute implements Command.Execute
+func (s *detachCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Detaching network %s from service %s", s.params.NetworkName, serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	// Use the dedicated network deletion endpoint
+	s.params.ServiceUUID = serviceUUID
+
+	err := svc.DeleteManagedObjectStorageNetwork(exec.Context(), &s.params)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	return output.OnlyMarshaled{Value: fmt.Sprintf("Network %s detached from service %s", s.params.NetworkName, serviceUUID)}, nil
+}

--- a/internal/commands/objectstorage/network/list.go
+++ b/internal/commands/objectstorage/network/list.go
@@ -1,0 +1,89 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// ListCommand creates the "network list" command
+func ListCommand() commands.Command {
+	return &listNetworksCommand{
+		BaseCommand: commands.New(
+			"list",
+			"List networks in a managed object storage service",
+			"upctl object-storage network list <service-uuid>",
+			"upctl object-storage network list my-service",
+		),
+	}
+}
+
+type listNetworksCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+}
+
+// InitCommand implements Command.InitCommand
+func (s *listNetworksCommand) InitCommand() {
+	s.Cobra().Long = commands.WrapLongDescription(`List networks in a managed object storage service
+
+Lists all networks attached to the specified managed object storage service, showing their names, UUIDs, types, and families.`)
+}
+
+// MaximumExecutions implements commands.MultipleArgumentCommand
+func (s *listNetworksCommand) MaximumExecutions() int {
+	return 1
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *listNetworksCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Listing networks in service %s", serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	// Get service details to access networks
+	req := &request.GetManagedObjectStorageRequest{
+		UUID: serviceUUID,
+	}
+
+	exec.PushProgressUpdateMessage(msg, msg)
+	res, err := svc.GetManagedObjectStorage(exec.Context(), req)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	rows := []output.TableRow{}
+	for _, network := range res.Networks {
+		uuid := "unknown"
+		if network.UUID != nil {
+			uuid = *network.UUID
+		}
+		rows = append(rows, output.TableRow{
+			network.Name,
+			uuid,
+			network.Type,
+			network.Family,
+		})
+	}
+
+	return output.MarshaledWithHumanOutput{
+		Value: res.Networks,
+		Output: output.Table{
+			Columns: []output.TableColumn{
+				{Key: "name", Header: "Name"},
+				{Key: "uuid", Header: "UUID"},
+				{Key: "type", Header: "Type"},
+				{Key: "family", Header: "Family"},
+			},
+			Rows: rows,
+		},
+	}, nil
+}

--- a/internal/commands/objectstorage/network/network.go
+++ b/internal/commands/objectstorage/network/network.go
@@ -1,0 +1,16 @@
+package network
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+)
+
+// BaseNetworkCommand creates the base "object-storage network" command
+func BaseNetworkCommand() commands.Command {
+	return &networkCommand{
+		BaseCommand: commands.New("network", "Manage networks in managed object storage services"),
+	}
+}
+
+type networkCommand struct {
+	*commands.BaseCommand
+}

--- a/internal/commands/objectstorage/objectstorage.go
+++ b/internal/commands/objectstorage/objectstorage.go
@@ -7,7 +7,6 @@ import (
 // BaseobjectstorageCommand creates the base "object-storage" command
 func BaseobjectstorageCommand() commands.Command {
 	baseCmd := commands.New("object-storage", "Manage managed object storage services")
-	baseCmd.SetDeprecatedAliases([]string{"objectstorage", "objsto"})
 
 	return &objectstorageCommand{
 		BaseCommand: baseCmd,
@@ -21,8 +20,4 @@ type objectstorageCommand struct {
 // InitCommand implements Command.InitCommand
 func (c *objectstorageCommand) InitCommand() {
 	c.Cobra().Aliases = []string{"obs", "objectstorage", "objsto"}
-
-	// Deprecating objectstorage and objsto in favour of object-storage
-	// TODO: Remove this in the future
-	commands.SetDeprecationHelp(c.Cobra(), c.DeprecatedAliases())
 }

--- a/internal/commands/objectstorage/regions.go
+++ b/internal/commands/objectstorage/regions.go
@@ -21,17 +21,10 @@ type regionsCommand struct {
 }
 
 func (s *regionsCommand) InitCommand() {
-	// Deprecating objectstorage and objsto in favour of object-storage
-	// TODO: Remove this in the future
-	commands.SetSubcommandDeprecationHelp(s, []string{"objectstorage", "objsto"})
 }
 
 // ExecuteWithoutArguments implements commands.NoArgumentCommand
 func (s *regionsCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
-	// Deprecating objectstorage and objsto in favour of object-storage
-	// TODO: Remove this in the future
-	commands.SetSubcommandExecutionDeprecationMessage(s, []string{"objectstorage", "objsto"}, "object-storage")
-
 	regions, err := exec.All().GetManagedObjectStorageRegions(exec.Context(), &request.GetManagedObjectStorageRegionsRequest{})
 	if err != nil {
 		return nil, err

--- a/internal/commands/objectstorage/show.go
+++ b/internal/commands/objectstorage/show.go
@@ -29,17 +29,10 @@ type showCommand struct {
 }
 
 func (c *showCommand) InitCommand() {
-	// Deprecating objectstorage and objsto in favour of object-storage
-	// TODO: Remove this in the future
-	commands.SetSubcommandDeprecationHelp(c, []string{"objectstorage", "objsto"})
 }
 
 // Execute implements commands.MultipleArgumentCommand
 func (c *showCommand) Execute(exec commands.Executor, uuid string) (output.Output, error) {
-	// Deprecating objectstorage and objsto in favour of object-storage
-	// TODO: Remove this in the future
-	commands.SetSubcommandExecutionDeprecationMessage(c, []string{"objectstorage", "objsto"}, "object-storage")
-
 	svc := exec.All()
 	objectStorage, err := svc.GetManagedObjectStorage(exec.Context(), &request.GetManagedObjectStorageRequest{UUID: uuid})
 	if err != nil {

--- a/internal/commands/objectstorage/user/create.go
+++ b/internal/commands/objectstorage/user/create.go
@@ -1,0 +1,67 @@
+package user
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/pflag"
+)
+
+type createCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	params createParams
+}
+
+type createParams struct {
+	request.CreateManagedObjectStorageUserRequest
+}
+
+// InitCommand implements Command.InitCommand
+func (s *createCommand) InitCommand() {
+	fs := &pflag.FlagSet{}
+	fs.StringVar(&s.params.Username, "username", "", "Username.")
+	s.AddFlags(fs)
+	commands.Must(s.Cobra().MarkFlagRequired("username"))
+}
+
+// CreateCommand creates the 'objectstorage user create' command
+func CreateCommand() commands.Command {
+	return &createCommand{
+		BaseCommand: commands.New(
+			"create",
+			"Create a user in managed object storage service",
+			"upctl object-storage user create <service-uuid> --username myuser",
+			"upctl object-storage user create my-service --username myuser",
+		),
+	}
+}
+
+// Execute implements Command.Execute
+func (s *createCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	s.params.ServiceUUID = serviceUUID
+
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Creating user %s in service %s", s.params.Username, serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	res, err := svc.CreateManagedObjectStorageUser(exec.Context(), &s.params.CreateManagedObjectStorageUserRequest)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	return output.MarshaledWithHumanDetails{Value: res, Details: []output.DetailRow{
+		{Title: "Username", Value: res.Username},
+		{Title: "ARN", Value: res.ARN},
+		{Title: "Created At", Value: res.CreatedAt},
+	}}, nil
+}

--- a/internal/commands/objectstorage/user/delete.go
+++ b/internal/commands/objectstorage/user/delete.go
@@ -1,0 +1,63 @@
+package user
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// DeleteCommand creates the 'objectstorage user delete' command
+func DeleteCommand() commands.Command {
+	return &deleteCommand{
+		BaseCommand: commands.New(
+			"delete",
+			"Delete a user from a managed object storage service",
+			"upctl object-storage user delete <service-uuid> --username myuser",
+			"upctl object-storage user delete my-service --username myuser",
+		),
+	}
+}
+
+type deleteCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+	params request.DeleteManagedObjectStorageUserRequest
+}
+
+// InitCommand implements Command.InitCommand
+func (s *deleteCommand) InitCommand() {
+	fs := s.Cobra().Flags()
+	fs.StringVar(&s.params.Username, "username", "", "The username of the user to delete.")
+	commands.Must(s.Cobra().MarkFlagRequired("username"))
+}
+
+// MaximumExecutions implements Command.MaximumExecutions
+func (s *deleteCommand) MaximumExecutions() int {
+	return 1
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *deleteCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	s.params.ServiceUUID = serviceUUID
+
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Deleting user %s from service %s", s.params.Username, serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	exec.PushProgressUpdateMessage(msg, msg)
+	err := svc.DeleteManagedObjectStorageUser(exec.Context(), &s.params)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	return output.OnlyMarshaled{Value: fmt.Sprintf("User %s deleted from service %s", s.params.Username, serviceUUID)}, nil
+}

--- a/internal/commands/objectstorage/user/list.go
+++ b/internal/commands/objectstorage/user/list.go
@@ -1,0 +1,71 @@
+package user
+
+import (
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/completion"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+)
+
+// ListCommand creates the 'objectstorage user list' command
+func ListCommand() commands.Command {
+	return &listUsersCommand{
+		BaseCommand: commands.New(
+			"list",
+			"List users in a managed object storage service",
+			"upctl object-storage user list <service-uuid>",
+			"upctl object-storage user list my-service",
+		),
+	}
+}
+
+type listUsersCommand struct {
+	*commands.BaseCommand
+	completion.ObjectStorage
+	resolver.CachingObjectStorage
+}
+
+// Execute implements commands.MultipleArgumentCommand
+func (s *listUsersCommand) Execute(exec commands.Executor, serviceUUID string) (output.Output, error) {
+	svc := exec.All()
+
+	msg := fmt.Sprintf("Listing users in service %s", serviceUUID)
+	exec.PushProgressStarted(msg)
+
+	// Build the request
+	req := &request.GetManagedObjectStorageUsersRequest{
+		ServiceUUID: serviceUUID,
+	}
+
+	exec.PushProgressUpdateMessage(msg, msg)
+	res, err := svc.GetManagedObjectStorageUsers(exec.Context(), req)
+	if err != nil {
+		return commands.HandleError(exec, msg, err)
+	}
+
+	exec.PushProgressSuccess(msg)
+
+	rows := []output.TableRow{}
+	for _, user := range res {
+		rows = append(rows, output.TableRow{
+			user.Username,
+			user.ARN,
+			user.CreatedAt.String(),
+		})
+	}
+
+	return output.MarshaledWithHumanOutput{
+		Value: res,
+		Output: output.Table{
+			Columns: []output.TableColumn{
+				{Key: "username", Header: "Username"},
+				{Key: "arn", Header: "ARN"},
+				{Key: "created_at", Header: "Created"},
+			},
+			Rows: rows,
+		},
+	}, nil
+}

--- a/internal/commands/objectstorage/user/user.go
+++ b/internal/commands/objectstorage/user/user.go
@@ -1,0 +1,16 @@
+package user
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+)
+
+// BaseUserCommand creates the base "object-storage user" command
+func BaseUserCommand() commands.Command {
+	return &userCommand{
+		BaseCommand: commands.New("user", "Manage users in managed object storage services"),
+	}
+}
+
+type userCommand struct {
+	*commands.BaseCommand
+}


### PR DESCRIPTION
### Object Storage Service Management

- **Service Creation**: Implemented `object-storage create` command with support for:
  - `--label` flag for setting labels during creation
  - `--network` flag for network attachment during creation
  - `--configured` flag for setting configured status
  - `--wait` flag that blocks until service reaches "running" state
  
  ### Bucket Management

  - **Bucket Operations**: Implemented bucket management:
  - `object-storage bucket create` - Create new buckets
  - `object-storage bucket delete` - Delete existing buckets
  - `object-storage bucket list` - List all buckets for a service


### Label Management

- **Dedicated Label Commands**: Added structured label management:
  - `object-storage label add` - Add labels to existing services
  - `object-storage label remove` - Remove specific labels from services
  - `object-storage label list` - List all labels for a service

### Network Management

- **Network Operations**: Added network management:
  - `object-storage network attach` - Attach networks to services
  - `object-storage network detach` - Detach networks from services

### User Management

- **User Operations**: Added user management:
  - `object-storage user create` - Create new users
  - `object-storage user delete` - Delete existing users
  - `object-storage user list` - List all users for a service
  - Access Key Management
  
      - **Access Key Operations**: Implemented access key management:
        - `object-storage create-access-key` - Generate new access keys for users
        - `object-storage delete-access-key` - Remove access keys
        - `object-storage list-access-keys` - List all access keys for a user