### PR TITLE
chore(ci): bump dependabot max open gomod PR limit to 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: gomod
+    open-pull-requests-limit: 15
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
To get a fuller picture. Might not be needed once all deps have been brought up to date once.