### PR TITLE
feat: audit log export support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Object storage user access key management with `object-storage create-access-key`, `object-storage delete-access-key`, and `object-storage list-access-keys` commands
 - Expose GPU limits in `account show` command
 - Expose GPU model and amount in `server plans` command
+- Add `audit-log export` command.
 
 ## [3.21.0] - 2025-07-15
 

--- a/internal/commands/auditlog/auditlog.go
+++ b/internal/commands/auditlog/auditlog.go
@@ -1,0 +1,21 @@
+package auditlog
+
+import (
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+)
+
+// BaseAuditLogCommand creates the base "audit-log" command
+func BaseAuditLogCommand() commands.Command {
+	return &auditLogCommand{
+		commands.New("audit-log", "Manage audit logs"),
+	}
+}
+
+type auditLogCommand struct {
+	*commands.BaseCommand
+}
+
+// InitCommand implements [commands.BaseCommand.InitCommand].
+func (c *auditLogCommand) InitCommand() {
+	c.Cobra().Aliases = []string{"auditlog", "al"}
+}

--- a/internal/commands/auditlog/export.go
+++ b/internal/commands/auditlog/export.go
@@ -1,0 +1,44 @@
+package auditlog
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/pflag"
+)
+
+var formats = []string{
+	request.ExportAuditLogFormatJSON,
+	request.ExportAuditLogFormatCSV,
+}
+
+// ExportCommand creates the "audit-log export" command
+func ExportCommand() commands.Command {
+	return &exportCommand{
+		BaseCommand: commands.New("export", "Export audit logs", "upctl audit-log export", "upctl audit-log export --output csv >audit-log.csv"),
+	}
+}
+
+type exportCommand struct {
+	*commands.BaseCommand
+	params request.ExportAuditLogRequest
+}
+
+func (c *exportCommand) InitCommand() {
+	fs := &pflag.FlagSet{}
+	fs.StringVar(&c.params.Format, "output", formats[0], fmt.Sprintf("Export format (typically %s). Note that this overrides the global --output flag.", strings.Join(formats, "|")))
+	c.AddFlags(fs)
+}
+
+// ExecuteWithoutArguments implements [commands.NoArgumentCommand].
+func (c *exportCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Output, error) {
+	r, err := exec.All().ExportAuditLog(exec.Context(), &c.params)
+	if err != nil {
+		return nil, err
+	}
+
+	return output.Raw{Source: r}, nil
+}

--- a/internal/commands/base/base.go
+++ b/internal/commands/base/base.go
@@ -6,6 +6,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/account/permissions"
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/account/token"
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/all"
+	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/auditlog"
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/database"
 	databaseindex "github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/database/index"
 	databaseproperties "github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/database/properties"
@@ -268,6 +269,10 @@ func BuildCommands(rootCmd *cobra.Command, conf *config.Config) {
 	partnerAccountCommand := commands.BuildCommand(partneraccount.BaseAccountCommand(), partnerCommand.Cobra(), conf)
 	commands.BuildCommand(partneraccount.CreateCommand(), partnerAccountCommand.Cobra(), conf)
 	commands.BuildCommand(partneraccount.ListCommand(), partnerAccountCommand.Cobra(), conf)
+
+	// Audit log operations
+	auditlogCommand := commands.BuildCommand(auditlog.BaseAuditLogCommand(), rootCmd, conf)
+	commands.BuildCommand(auditlog.ExportCommand(), auditlogCommand.Cobra(), conf)
 
 	// Operations for managing all resources at once
 	allCommand := commands.BuildCommand(all.BaseAllCommand(), rootCmd, conf)

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -3,6 +3,7 @@ package mock
 
 import (
 	"context"
+	"io"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
@@ -96,6 +97,7 @@ var (
 	_ service.ManagedObjectStorage = &Service{}
 	_ service.Gateway              = &Service{}
 	_ service.Token                = &Service{}
+	_ service.AuditLog             = &Service{}
 )
 
 // GetServerConfigurations implements service.Server.GetServerConfigurations
@@ -1555,4 +1557,13 @@ func (m *Service) GetBillingSummary(_ context.Context, r *request.GetBillingSumm
 		return nil, args.Error(1)
 	}
 	return args[0].(*upcloud.BillingSummary), args.Error(1)
+}
+
+// ExportAuditLog implements service.AuditLog.ExportAuditLog
+func (m *Service) ExportAuditLog(_ context.Context, r *request.ExportAuditLogRequest) (io.ReadCloser, error) {
+	args := m.Called(r)
+	if args[0] == nil {
+		return nil, args.Error(1)
+	}
+	return args[0].(io.ReadCloser), args.Error(1)
 }

--- a/internal/output/raw.go
+++ b/internal/output/raw.go
@@ -1,21 +1,33 @@
 package output
 
-import "fmt"
+import "io"
 
-// Raw is a way to output raw data to the user. It is *only* supported in humanized output and used for generating shell completion scripts.
-type Raw []byte
+// Raw is a way to output raw data from a source reader.
+type Raw struct {
+	Source io.ReadCloser
+}
 
 // MarshalJSON implements output.Output
 func (s Raw) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("json output not supported")
+	return []byte{}, nil
 }
 
 // MarshalHuman implements output.Output
 func (s Raw) MarshalHuman() ([]byte, error) {
-	return s, nil
+	return []byte{}, nil
 }
 
 // MarshalRawMap implements output.Output
 func (s Raw) MarshalRawMap() (map[string]interface{}, error) {
-	return nil, fmt.Errorf("raw mao output not supported")
+	return map[string]interface{}{}, nil
+}
+
+// Read implements io.ReadCloser.
+func (s Raw) Read(p []byte) (n int, err error) {
+	return s.Source.Read(p)
+}
+
+// Close implements io.ReadCloser.
+func (s Raw) Close() error {
+	return s.Source.Close()
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -25,4 +25,5 @@ type AllServices interface {
 	service.Partner
 	service.Token
 	service.Tag
+	service.AuditLog
 }


### PR DESCRIPTION
Requires https://github.com/UpCloudLtd/upcloud-go-api/pull/377 and updated to a new upcloud-go-api release containing it.