### PR TITLE
feat: expose GPUs in account and server plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Object storage bucket management with `object-storage bucket create`, `object-storage bucket delete`, and `object-storage bucket list` commands
 - Object storage user management with `object-storage user create`, `object-storage user delete`, and `object-storage user list` commands
 - Object storage user access key management with `object-storage create-access-key`, `object-storage delete-access-key`, and `object-storage list-access-keys` commands
+- Expose GPU limits in `account show` command
+- Expose GPU model and amount in `server plans` command
 
 ## [3.21.0] - 2025-07-15
 

--- a/internal/commands/account/show.go
+++ b/internal/commands/account/show.go
@@ -103,6 +103,11 @@ func (s *showCommand) ExecuteWithoutArguments(exec commands.Executor) (output.Ou
 						Key:   "storage_ssd",
 						Value: account.ResourceLimits.StorageSSD,
 					},
+					{
+						Title: "GPUs:",
+						Key:   "gpus",
+						Value: account.ResourceLimits.GPUs,
+					},
 				},
 			},
 		},

--- a/internal/commands/account/show_test.go
+++ b/internal/commands/account/show_test.go
@@ -33,6 +33,7 @@ func TestShowCommand(t *testing.T) {
 			StorageMaxIOPS:        10240,
 			StorageSSD:            10240,
 			LoadBalancers:         50,
+			GPUs:                  10,
 		},
 	}
 
@@ -54,6 +55,7 @@ func TestShowCommand(t *testing.T) {
     Storage HDD:              10240 
     Storage MaxIOPS:          10240 
     Storage SSD:              10240 
+    GPUs:                        10 
 
 `
 

--- a/internal/commands/server/plan_list.go
+++ b/internal/commands/server/plan_list.go
@@ -50,6 +50,8 @@ func (s *planListCommand) ExecuteWithoutArguments(exec commands.Executor) (outpu
 			p.StorageSize,
 			p.StorageTier,
 			p.PublicTrafficOut,
+			p.GPUModel,
+			p.GPUAmount,
 		})
 	}
 
@@ -97,6 +99,8 @@ func planSection(key, title string, rows []output.TableRow) output.CombinedSecti
 				{Key: "storage", Header: "Storage size"},
 				{Key: "storage_tier", Header: "Storage tier"},
 				{Key: "egress_transfer", Header: "Transfer out (GiB/month)"},
+				{Key: "gpu_model", Header: "GPU model"},
+				{Key: "gpu_amount", Header: "GPU amount"},
 			},
 			Rows: rows,
 		},

--- a/internal/commands/server/plan_list.go
+++ b/internal/commands/server/plan_list.go
@@ -43,16 +43,21 @@ func (s *planListCommand) ExecuteWithoutArguments(exec commands.Executor) (outpu
 	rows := make(map[string][]output.TableRow)
 	for _, p := range plans {
 		key := planType(p)
-		rows[key] = append(rows[key], output.TableRow{
+		row := output.TableRow{
 			p.Name,
 			p.CoreNumber,
 			p.MemoryAmount,
 			p.StorageSize,
 			p.StorageTier,
 			p.PublicTrafficOut,
-			p.GPUModel,
-			p.GPUAmount,
-		})
+		}
+
+		// Add GPU fields only for GPU plans
+		if key == "gpu" {
+			row = append(row, p.GPUModel, p.GPUAmount)
+		}
+
+		rows[key] = append(rows[key], row)
 	}
 
 	return output.MarshaledWithHumanOutput{
@@ -88,21 +93,28 @@ func planType(p upcloud.Plan) string {
 }
 
 func planSection(key, title string, rows []output.TableRow) output.CombinedSection {
+	columns := []output.TableColumn{
+		{Key: "name", Header: "Name"},
+		{Key: "cores", Header: "Cores"},
+		{Key: "memory", Header: "Memory"},
+		{Key: "storage", Header: "Storage size"},
+		{Key: "storage_tier", Header: "Storage tier"},
+		{Key: "egress_transfer", Header: "Transfer out (GiB/month)"},
+	}
+
+	if key == "gpu" {
+		columns = append(columns,
+			output.TableColumn{Key: "gpu_model", Header: "GPU model"},
+			output.TableColumn{Key: "gpu_amount", Header: "GPU amount"},
+		)
+	}
+
 	return output.CombinedSection{
 		Key:   key,
 		Title: title,
 		Contents: output.Table{
-			Columns: []output.TableColumn{
-				{Key: "name", Header: "Name"},
-				{Key: "cores", Header: "Cores"},
-				{Key: "memory", Header: "Memory"},
-				{Key: "storage", Header: "Storage size"},
-				{Key: "storage_tier", Header: "Storage tier"},
-				{Key: "egress_transfer", Header: "Transfer out (GiB/month)"},
-				{Key: "gpu_model", Header: "GPU model"},
-				{Key: "gpu_amount", Header: "GPU amount"},
-			},
-			Rows: rows,
+			Columns: columns,
+			Rows:    rows,
 		},
 	}
 }


### PR DESCRIPTION
- New columns in "server plans" command to expose the GPU model and amount for GPU enabled plans
- New field in "account show" command to expose GPU limits

Needs #494 