### PR TITLE
fix: prevent filename completion of flags that don't take filename args

### DIFF
--- a/internal/commands/database/create.go
+++ b/internal/commands/database/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -199,6 +200,9 @@ func (s *createCommand) InitCommand() {
 	commands.Must(s.Cobra().MarkFlagRequired("title"))
 	commands.Must(s.Cobra().MarkFlagRequired("zone"))
 	commands.Must(s.Cobra().MarkFlagRequired("hostname-prefix"))
+	for _, flag := range []string{"hostname-prefix", "title", "plan", "maintenance-dow", "maintenance-time", "label", "network", "property"} {
+		commands.Must(s.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 func (s *createCommand) InitCommandWithConfig(cfg *config.Config) {

--- a/internal/commands/database/session/cancel.go
+++ b/internal/commands/database/session/cancel.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -42,7 +43,7 @@ func (s *cancelCommand) InitCommand() {
 
 	s.AddFlags(flagSet)
 	commands.Must(s.Cobra().MarkFlagRequired("pid"))
-	commands.Must(flagSet.SetAnnotation("pid", commands.FlagAnnotationNoFileCompletions, nil))
+	commands.Must(s.Cobra().RegisterFlagCompletionFunc("pid", cobra.NoFileCompletions))
 }
 
 // Execute implements commands.MultipleArgumentCommand

--- a/internal/commands/ipaddress/modify.go
+++ b/internal/commands/ipaddress/modify.go
@@ -8,6 +8,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -37,6 +38,9 @@ func (s *modifyCommand) InitCommand() {
 	fs.StringVar(&s.mac, "mac", "", "MAC address of server interface to attach floating IP to.")
 	fs.StringVar(&s.ptrrecord, "ptr-record", "", "New fully qualified domain name to set as the PTR record for the IP address.")
 	s.AddFlags(fs)
+	for _, flag := range []string{"mac", "ptr-record"} {
+		commands.Must(s.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 // MaximumExecutions implements Command.MaximumExecutions

--- a/internal/commands/kubernetes/modify.go
+++ b/internal/commands/kubernetes/modify.go
@@ -55,7 +55,9 @@ func (c *modifyCommand) InitCommand() {
 
 	c.AddFlags(fs)
 	c.Cobra().MarkFlagsMutuallyExclusive("label", "clear-labels")
-	commands.Must(c.Cobra().RegisterFlagCompletionFunc("label", cobra.NoFileCompletions))
+	for _, flag := range []string{"kubernetes-api-allow-ip", "label"} {
+		commands.Must(c.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 // Execute implements commands.MultipleArgumentCommand

--- a/internal/commands/kubernetes/nodegroup/create.go
+++ b/internal/commands/kubernetes/nodegroup/create.go
@@ -47,6 +47,7 @@ func GetCreateNodeGroupFlagSet(p *CreateNodeGroupParams) *pflag.FlagSet {
 	commands.Must(fs.SetAnnotation("label", commands.FlagAnnotationNoFileCompletions, nil))
 	commands.Must(fs.SetAnnotation("name", commands.FlagAnnotationNoFileCompletions, nil))
 	commands.Must(fs.SetAnnotation("plan", commands.FlagAnnotationNoFileCompletions, nil))
+	commands.Must(fs.SetAnnotation("ssh-key", commands.FlagAnnotationNoFileCompletions, nil))
 	commands.Must(fs.SetAnnotation("storage", commands.FlagAnnotationNoFileCompletions, nil))
 	commands.Must(fs.SetAnnotation("taint", commands.FlagAnnotationNoFileCompletions, nil))
 

--- a/internal/commands/network/create.go
+++ b/internal/commands/network/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/ui"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -58,6 +59,9 @@ func (s *createCommand) InitCommand() {
 	commands.Must(s.Cobra().MarkFlagRequired("name"))
 	commands.Must(s.Cobra().MarkFlagRequired("zone"))
 	commands.Must(s.Cobra().MarkFlagRequired("ip-network"))
+	for _, flag := range []string{"name", "ip-network"} {
+		commands.Must(s.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 func (s *createCommand) InitCommandWithConfig(cfg *config.Config) {

--- a/internal/commands/network/modify.go
+++ b/internal/commands/network/modify.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
@@ -52,6 +53,9 @@ func (s *modifyCommand) InitCommand() {
 		"  dhcp-default-route: true/false \n"+
 		"  dhcp-dns: array of strings")
 	s.AddFlags(fs)
+	for _, flag := range []string{"name", "ip-network"} {
+		commands.Must(s.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 // ExecuteSingleArgument implements commands.SingleArgumentCommand

--- a/internal/commands/server/create.go
+++ b/internal/commands/server/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
 	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -301,6 +302,12 @@ Note that the default template, Ubuntu Server 24.04 LTS (Noble Numbat), only sup
 
 	commands.Must(s.Cobra().MarkFlagRequired("hostname"))
 	commands.Must(s.Cobra().MarkFlagRequired("zone"))
+	for _, flag := range []string{
+		"boot-order", "cores", "hostname", "label", "memory", "network", "os", "os-storage-size", "remote-access-password",
+		"simple-backup", "storage", "title", "user-data", "username",
+	} {
+		commands.Must(s.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 func (s *createCommand) InitCommandWithConfig(cfg *config.Config) {

--- a/internal/commands/server/firewall/create.go
+++ b/internal/commands/server/firewall/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
 	"github.com/m7shapan/cidr"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -77,6 +78,12 @@ To edit the default rule of the firewall, set only ` + "`" + `--direction` + "`"
 	commands.Must(s.Cobra().MarkFlagRequired("action"))
 	s.Cobra().MarkFlagsRequiredTogether("destination-port-start", "destination-port-end")
 	s.Cobra().MarkFlagsRequiredTogether("source-port-start", "source-port-end")
+	for _, flag := range []string{
+		"position", "icmp-type", "dest-ipaddress-block", "destination-port-start", "destination-port-end",
+		"src-ipaddress-block", "source-port-start", "source-port-end", "comment",
+	} {
+		commands.Must(s.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 // Execute implements commands.MultipleArgumentCommand

--- a/internal/commands/server/firewall/delete.go
+++ b/internal/commands/server/firewall/delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/output"
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -36,6 +37,7 @@ func (s *deleteCommand) InitCommand() {
 	s.AddFlags(flagSet)
 
 	commands.Must(s.Cobra().MarkFlagRequired("position"))
+	commands.Must(s.Cobra().RegisterFlagCompletionFunc("position", cobra.NoFileCompletions))
 }
 
 // Execute implements commands.MultipleArgumentCommand

--- a/internal/commands/server/modify.go
+++ b/internal/commands/server/modify.go
@@ -11,6 +11,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -71,6 +72,12 @@ func (s *modifyCommand) InitCommand() {
 	flags.StringVar(&s.params.RemoteAccessPassword, "remote-access-password", defaultModifyParams.RemoteAccessPassword, "The remote access password.")
 
 	s.AddFlags(flags)
+
+	for _, flag := range []string{
+		"boot-order", "cores", "hostname", "label", "memory", "remote-access-password", "simple-backup", "title",
+	} {
+		commands.Must(s.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 // Execute implements commands.MultipleArgumentCommand

--- a/internal/commands/server/networkinterface/create.go
+++ b/internal/commands/server/networkinterface/create.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -61,6 +62,9 @@ func (s *createCommand) InitCommand() {
 	config.AddEnableDisableFlags(fs, &s.sourceIPFiltering, "source-ip-filtering", "Whether source IP filtering is enabled on the interface. Disabling it is allowed only for SDN private interfaces.")
 	fs.StringSliceVar(&s.ipAddresses, "ip-addresses", []string{}, "A comma-separated list of IP addresses")
 	s.AddFlags(fs)
+	for _, flag := range []string{"index", "ip-addresses"} {
+		commands.Must(s.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 func (s *createCommand) InitCommandWithConfig(cfg *config.Config) {

--- a/internal/commands/server/networkinterface/modify.go
+++ b/internal/commands/server/networkinterface/modify.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -47,6 +48,9 @@ func (s *modifyCommand) InitCommand() {
 
 	s.AddFlags(fs) // TODO(ana): replace usage with examples once the refactor is done.
 	commands.Must(s.Cobra().MarkFlagRequired("index"))
+	for _, flag := range []string{"index", "new-index", "bootable", "source-ip-filtering", "ip-addresses"} {
+		commands.Must(s.Cobra().RegisterFlagCompletionFunc(flag, cobra.NoFileCompletions))
+	}
 }
 
 // MaximumExecutions implements Command.MaximumExecutions

--- a/internal/commands/server/storage/attach.go
+++ b/internal/commands/server/storage/attach.go
@@ -11,6 +11,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -59,6 +60,7 @@ func (s *attachCommand) InitCommand() {
 
 	s.AddFlags(flagSet)
 	commands.Must(s.Cobra().MarkFlagRequired("storage"))
+	commands.Must(s.Cobra().RegisterFlagCompletionFunc("address", cobra.NoFileCompletions))
 }
 
 // MaximumExecutions implements command.Command

--- a/internal/commands/server/storage/detach.go
+++ b/internal/commands/server/storage/detach.go
@@ -9,6 +9,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/resolver"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -48,6 +49,7 @@ func (s *detachCommand) InitCommand() {
 
 	s.AddFlags(flagSet)
 	commands.Must(s.Cobra().MarkFlagRequired("address"))
+	commands.Must(s.Cobra().RegisterFlagCompletionFunc("address", cobra.NoFileCompletions))
 }
 
 // MaximumExecutions implements command.Command

--- a/internal/commands/storage/backup/create.go
+++ b/internal/commands/storage/backup/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/ui"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -49,6 +50,7 @@ func (s *createBackupCommand) InitCommand() {
 
 	s.AddFlags(flagSet)
 	commands.Must(s.Cobra().MarkFlagRequired("title"))
+	commands.Must(s.Cobra().RegisterFlagCompletionFunc("title", cobra.NoFileCompletions))
 }
 
 // Execute implements commands.MultipleArgumentCommand

--- a/internal/commands/storage/clone.go
+++ b/internal/commands/storage/clone.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -59,6 +60,7 @@ func (s *cloneCommand) InitCommand() {
 	s.AddFlags(flagSet)
 	commands.Must(s.Cobra().MarkFlagRequired("title"))
 	commands.Must(s.Cobra().MarkFlagRequired("zone"))
+	commands.Must(s.Cobra().RegisterFlagCompletionFunc("title", cobra.NoFileCompletions))
 }
 
 func (s *cloneCommand) InitCommandWithConfig(cfg *config.Config) {

--- a/internal/commands/storage/create.go
+++ b/internal/commands/storage/create.go
@@ -85,6 +85,9 @@ func applyCreateFlags(fs *pflag.FlagSet, dst, def *createParams) {
 	fs.StringVar(&dst.backupTime, "backup-time", def.backupTime, "The time when to create a backup in HH:MM. Empty value means no backups.")
 	fs.StringVar(&dst.BackupRule.Interval, "backup-interval", def.BackupRule.Interval, "The interval of the backup.\nAvailable: daily, mon, tue, wed, thu, fri, sat, sun")
 	fs.IntVar(&dst.BackupRule.Retention, "backup-retention", def.BackupRule.Retention, "How long to store the backups in days. The accepted range is 1-1095")
+	for _, flag := range []string{"title", "size", "backup-time", "backup-retention"} {
+		commands.Must(fs.SetAnnotation(flag, commands.FlagAnnotationNoFileCompletions, nil))
+	}
 }
 
 // InitCommand implements Command.InitCommand

--- a/internal/commands/storage/modify.go
+++ b/internal/commands/storage/modify.go
@@ -70,6 +70,9 @@ func (s *modifyCommand) InitCommand() {
 	config.AddEnableOrDisableFlag(flagSet, &s.autoresizePartitionFilesystem, false, "filesystem-autoresize", "automatic resize of partition and filesystem when modifying storage size. Note that before the resize attempt is made, backup of the storage will be taken. If the resize attempt fails, the backup will be used to restore the storage and then deleted. If the resize attempt succeeds, backup will be kept. Taking and keeping backups incur costs.")
 
 	s.AddFlags(flagSet)
+	for _, flag := range []string{"title", "size", "backup-time", "backup-retention"} {
+		commands.Must(flagSet.SetAnnotation(flag, commands.FlagAnnotationNoFileCompletions, nil))
+	}
 }
 
 func setBackupFields(storageUUID string, p modifyParams, exec commands.Executor, req *request.ModifyStorageRequest) error {

--- a/internal/commands/storage/templatize.go
+++ b/internal/commands/storage/templatize.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -55,6 +56,7 @@ func (s *templatizeCommand) InitCommand() {
 
 	s.AddFlags(flagSet)
 	commands.Must(s.Cobra().MarkFlagRequired("title"))
+	commands.Must(s.Cobra().RegisterFlagCompletionFunc("title", cobra.NoFileCompletions))
 }
 
 // Execute implements commands.MultipleArgumentCommand

--- a/internal/completion/account_test.go
+++ b/internal/completion/account_test.go
@@ -46,5 +46,5 @@ func TestAccount_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetAccountList", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	ips, directive := completion.Account{}.CompleteArgument(context.TODO(), mService, "127")
 	assert.Nil(t, ips)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/database_test.go
+++ b/internal/completion/database_test.go
@@ -47,5 +47,5 @@ func TestDatabase_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetManagedDatabases", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	completions, directive := completion.Database{}.CompleteArgument(context.TODO(), mService, "asd")
 	assert.Nil(t, completions)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/ipaddress_test.go
+++ b/internal/completion/ipaddress_test.go
@@ -47,5 +47,5 @@ func TestIPAddress_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetIPAddresses", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	ips, directive := completion.IPAddress{}.CompleteArgument(context.TODO(), mService, "127")
 	assert.Nil(t, ips)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/kubernetes_test.go
+++ b/internal/completion/kubernetes_test.go
@@ -48,5 +48,5 @@ func TestKubernetes_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetKubernetesClusters", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	completions, directive := completion.Kubernetes{}.CompleteArgument(context.TODO(), mService, "asd")
 	assert.Nil(t, completions)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/loadbalancer_test.go
+++ b/internal/completion/loadbalancer_test.go
@@ -47,5 +47,5 @@ func TestLoadBalancer_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetLoadBalancers", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	completions, directive := completion.LoadBalancer{}.CompleteArgument(context.TODO(), mService, "asd")
 	assert.Nil(t, completions)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/network_test.go
+++ b/internal/completion/network_test.go
@@ -53,5 +53,5 @@ func TestNetwork_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetNetworks", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	ips, directive := completion.Network{}.CompleteArgument(context.TODO(), mService, "127")
 	assert.Nil(t, ips)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/none.go
+++ b/internal/completion/none.go
@@ -4,5 +4,5 @@ import "github.com/spf13/cobra"
 
 // None is a fallback with no completion, for error cases etc.
 func None(_ string) ([]string, cobra.ShellCompDirective) {
-	return nil, cobra.ShellCompDirectiveDefault
+	return nil, cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/completion/router_test.go
+++ b/internal/completion/router_test.go
@@ -49,5 +49,5 @@ func TestRouter_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetRouters", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	ips, directive := completion.Router{}.CompleteArgument(context.TODO(), mService, "127")
 	assert.Nil(t, ips)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/server_test.go
+++ b/internal/completion/server_test.go
@@ -66,5 +66,5 @@ func TestServer_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetServers", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	ips, directive := completion.Server{}.CompleteArgument(context.TODO(), mService, "127")
 	assert.Nil(t, ips)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/servergroup_test.go
+++ b/internal/completion/servergroup_test.go
@@ -50,5 +50,5 @@ func TestServerGroup_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetServerGroups", &request.GetServerGroupsRequest{}, mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	ips, directive := completion.ServerGroup{}.CompleteArgument(context.TODO(), mService, "127")
 	assert.Nil(t, ips)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/storage_test.go
+++ b/internal/completion/storage_test.go
@@ -49,5 +49,5 @@ func TestStorage_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetStorages", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	ips, directive := completion.Storage{}.CompleteArgument(context.TODO(), mService, "127")
 	assert.Nil(t, ips)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }

--- a/internal/completion/token_test.go
+++ b/internal/completion/token_test.go
@@ -53,5 +53,5 @@ func TestToken_CompleteArgumentServiceFail(t *testing.T) {
 	mService.On("GetTokens", mock.Anything).Return(nil, fmt.Errorf("MOCKFAIL"))
 	tokens, directive := completion.Token{}.CompleteArgument(context.TODO(), mService, "FOO")
 	assert.Nil(t, tokens)
-	assert.Equal(t, cobra.ShellCompDirectiveDefault, directive)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }


### PR DESCRIPTION
Similar as/continuation of #366, splitting off #491.