### PR TITLE
fix(release): PKGBUILD null directory

### DIFF
--- a/scripts/generate_aur_pkgbuild.sh
+++ b/scripts/generate_aur_pkgbuild.sh
@@ -23,7 +23,6 @@ source=("https://github.com/UpCloudLtd/\${pkgname}/releases/download/v\${pkgver}
 sha256sums=('${PKG_HASH}')
 
 package() {
-    cd "\$pkgname_\$pkgver_linux_x86_64"
     install -Dm755 upctl "\$pkgdir/usr/local/bin/upctl"
 }
 EOF


### PR DESCRIPTION
As reported here: https://aur.archlinux.org/packages/upcloud-cli#comment-1032759

The current PKGBUILD results in 

```
==> Starting package()...
/home/kainoa/.cache/yay/upcloud-cli/PKGBUILD: line 12: cd: null directory
==> ERROR: A failure occurred in package().
    Aborting...
 -> error making: upcloud-cli-exit status 4
```

Removing that `cd` line results in a successful installation.