### PR TITLE
chore(deps): bump Go version to v1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/UpCloudLtd/upcloud-cli/v3
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.0
 
 require (
 	github.com/UpCloudLtd/progress v1.0.3


### PR DESCRIPTION
Changes:

- Bump Go version to the latest v1.25.0
- Fix a storage import test by using platform-agnostic err checks. Previously the test used a platform-specific error message. The behaviour changed in Go 1.25 due to https://go-review.googlesource.com/c/go/+/671458 and broke the test on Windows.