### PR TITLE
chore(deps): bump Go version to 1.25.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/upcloud-cli/v3
 
-go 1.25.0
+go 1.25.3
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Contains security and bug fixes.

See Go milestones for futher info:

- [Go 1.25.1](https://github.com/golang/go/issues?q=milestone%3AGo1.25.1+label%3ACherryPickApproved)
- [Go 1.25.2](https://github.com/golang/go/issues?q=milestone%3AGo1.25.2+label%3ACherryPickApproved)
- [Go 1.25.3](https://github.com/golang/go/issues?q=milestone%3AGo1.25.3+label%3ACherryPickApproved)