### PR TITLE
chore(deps): switch from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,10 +19,10 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/zalando/go-keyring v0.2.6
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/term v0.38.0
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.19.2
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
@@ -128,7 +128,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
@@ -140,6 +139,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.0 // indirect
 	k8s.io/apiserver v0.34.0 // indirect
 	k8s.io/cli-runtime v0.34.2 // indirect

--- a/internal/commands/kubernetes/config.go
+++ b/internal/commands/kubernetes/config.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )

--- a/internal/commands/kubernetes/config_test.go
+++ b/internal/commands/kubernetes/config_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )

--- a/internal/commands/stack/supabase/supabase.go
+++ b/internal/commands/stack/supabase/supabase.go
@@ -11,7 +11,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-cli/v3/internal/commands/stack"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type ChartVersion string

--- a/internal/output/yaml.go
+++ b/internal/output/yaml.go
@@ -1,7 +1,7 @@
 package output
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // JSONToYAML converts JSON bytes into YAML bytes. This allows using key names from JSON field tags also for YAML output. This has some side-effects (e.g., timestamps will be double-quoted in output) but this is lesser evil than adding yaml field tags everywhere in our Go types.


### PR DESCRIPTION
See https://github.com/yaml/go-yaml#project-status.

Various dependencies have already switched, most recently [cobra in 1.10.2](https://github.com/spf13/cobra/releases/tag/v1.10.2).

For a diff between the old 3.0.1 and the new 3.0.2, see https://gist.github.com/scop/6ec72debf62a9603cff9dc97e6814ddd. 3.0.1 are identical.

Upgrade to 3.0.4 while at it: https://github.com/yaml/go-yaml/compare/v3.0.2...v3.0.4