### PR TITLE
chore(ci): use reusable workflow to attest build provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      attestations: write
       contents: write
-      id-token: write
       packages: write
+    outputs:
+      checksums: ${{ steps.capture_checksums.outputs.checksums }}
     steps:
       - name: Checkout head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -57,10 +57,14 @@ jobs:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       - name: Clear Docker login session
         run: rm -f ${HOME}/.docker/config.json
-      - name: Generate artifact attestations
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        with:
-          subject-checksums: dist/checksums.txt
+      - name: Capture dist checksums in an output string
+        id: capture_checksums
+        run: |
+          {
+            echo "checksums<<EOF"
+            cat dist/checksums.txt
+            echo "EOF"
+          } >>"$GITHUB_OUTPUT"
       - name: Generate AUR PKGBUILD
         run: ./scripts/generate_aur_pkgbuild.sh ${{ steps.git.outputs.tag_version }}
       - name: Publish AUR package
@@ -73,3 +77,14 @@ jobs:
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: Release ${{ steps.git.outputs.tag_version }}
           force_push: true
+
+  attest:
+    name: Attest
+    needs:
+      - publish_release
+    permissions:
+      attestations: write # to persist
+      id-token: write     # to sign
+    uses: UpCloudLtd/workflows/.github/workflows/build-provenance.yaml@main
+    with:
+      subject-checksums: ${{ needs.publish_release.outputs.checksums }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,10 +138,12 @@ and plain old checksum files are available for verifying release assets.
     ```sh
     gh attestation verify \
         /path/to/locally/downloaded/upcloud-cli_{{ latest_release }}_linux_x86_64.tar.gz \
-        --repo UpCloudLtd/upcloud-cli
+        --repo UpCloudLtd/upcloud-cli \
+        --signer-repo UpCloudLtd/workflows
     ```
 
     Attestations are available starting from version 3.16.0.
+    To verify attestations for versions older than 3.28.0, leave out `--signer-repo`.
 
 === "Digests"
 


### PR DESCRIPTION
For SLSA level 3.

Refs
- https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/increase-security-rating
- https://github.blog/enterprise-software/devsecops/enhance-build-security-and-reach-slsa-level-3-with-github-artifact-attestations/#achieving-slsa-level-3-compliance-with-github-artifact-attestations

Closes https://github.com/UpCloudLtd/upcloud-cli/issues/426