### PR TITLE
chore(docs): enable `content.code.copy` feature

### DIFF
--- a/mkdocs.base.yaml
+++ b/mkdocs.base.yaml
@@ -27,6 +27,7 @@ theme:
   favicon: favicon.svg
   language: en
   features:
+    - content.code.copy
     - navigation.instant
 
 plugins:


### PR DESCRIPTION
This adds _copy_ buttons to code-snippets 📋 