### PR TITLE
chore: prepare release v3.32.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,15 @@ jobs:
             cat dist/checksums.txt
             echo "EOF"
           } >>"$GITHUB_OUTPUT"
+
+  aur:
+    name: AUR
+    runs-on: ubuntu-latest
+    needs:
+      - publish_release
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate AUR PKGBUILD
         run: ./scripts/generate_aur_pkgbuild.sh ${{ steps.git.outputs.tag_version }}
       - name: Publish AUR package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.32.1] - 2026-04-27
+
+### Fixed
+
+- Create attestations from publish workflow even if AUR release fails.
+
 ## [3.32.0] - 2026-04-17
 
 ### Added
@@ -702,7 +708,8 @@ Initial public beta release :tada:
 ### Added
 - Current feature set added! First internal release
 
-[Unreleased]: https://github.com/UpCloudLtd/upcloud-cli/compare/v3.32.0...HEAD
+[Unreleased]: https://github.com/UpCloudLtd/upcloud-cli/compare/v3.32.1...HEAD
+[3.32.1]: https://github.com/UpCloudLtd/upcloud-cli/compare/v3.32.0...v3.32.1
 [3.32.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v3.31.0...v3.32.0
 [3.31.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v3.30.0...v3.31.0
 [3.30.0]: https://github.com/UpCloudLtd/upcloud-cli/compare/v3.29.0...v3.30.0


### PR DESCRIPTION
v3.32.0 is missing release attestation because AUR publish failed. #755 should have fixed failing AUR steps, but we could use separate job for AUR release to avoid it blocking creating attestations.