### PR TITLE
fix: get version for AUR from `github.ref_name`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,9 +39,6 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
-      - name: Get tag version
-        id: git
-        run: echo "tag_version=$(make version)" >> "$GITHUB_OUTPUT"
       - name: Get release notes
         id: release_notes
         run: make release-notes > .release_notes
@@ -75,7 +72,7 @@ jobs:
       - name: Checkout head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate AUR PKGBUILD
-        run: ./scripts/generate_aur_pkgbuild.sh ${{ steps.git.outputs.tag_version }}
+        run: ./scripts/generate_aur_pkgbuild.sh ${{ github.ref_name }}
       - name: Publish AUR package
         uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
         with:
@@ -84,7 +81,7 @@ jobs:
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: Release ${{ steps.git.outputs.tag_version }}
+          commit_message: Release ${{ github.ref_name }}
           force_push: true
 
   attest:


### PR DESCRIPTION
The workflow is only triggered on new tags, so `github.ref_name` should always match `make version` output.